### PR TITLE
add test to variable transformation in recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation("com.github.rjeschke:txtmark:0.13")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testCompile("org.mockito:mockito-core:4.2.0")
 }
 
 // Configure gradle-intellij-plugin plugin.
@@ -92,3 +91,4 @@ tasks {
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 }
+

--- a/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthTwoDigits.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthTwoDigits.java
@@ -19,7 +19,7 @@ public class VariableTransformerMonthTwoDigits implements VariableTransformer {
   public String transform(String code, CodingAssistantContext CodigaTransformationContext){
     final Calendar calendar = Calendar.getInstance();
     final Date date = calendar.getTime();
-    return code.replace(CodingAssistantContext.DATE_MONTH_NAME,
+    return code.replace(CodingAssistantContext.DATE_MONTH_TWO_DIGITS,
       new SimpleDateFormat("mm", Locale.ENGLISH).format(date.getTime()));
   }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearShort.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearShort.java
@@ -19,7 +19,7 @@ public class VariableTransformerYearShort implements VariableTransformer {
   public String transform(String code, CodingAssistantContext CodigaTransformationContext){
     final Calendar calendar = Calendar.getInstance();
     final Date date = calendar.getTime();
-    return code.replace(CodingAssistantContext.DATE_CURRENT_YEAR,
+    return code.replace(CodingAssistantContext.DATE_CURRENT_YEAR_SHORT,
       new SimpleDateFormat("YY", Locale.ENGLISH).format(date.getTime()));
   }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProvider.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProvider.java
@@ -184,34 +184,33 @@ public class CodigaCompletionProvider extends CompletionProvider<CompletionParam
             language,
             filename);
 
-
         LOGGER.debug(String.format("found %s recipes", recipes.size()));
 
         /**
          * We take only the top three recipes (they come ranked in order from the API).
          * For each of them, add a completion item and add a routine to insert the code.
          */
-        for(GetRecipesForClientQuery.GetRecipesForClient recipe: recipes.stream().limit(NUMBER_OF_RECIPES_TO_KEEP_FOR_COMPLETION).collect(Collectors.toList())){
-            List<String> recipeKeywords = new ArrayList<>(recipe.keywords());
-            if (recipe.shortcut() != null) {
-                recipeKeywords.add(recipe.shortcut());
-            }
+        for (GetRecipesForClientQuery.GetRecipesForClient recipe : recipes.stream()
+          .limit(NUMBER_OF_RECIPES_TO_KEEP_FOR_COMPLETION).collect(Collectors.toList())) {
+          List<String> recipeKeywords = new ArrayList<>(recipe.keywords());
+          if (recipe.shortcut() != null) {
+            recipeKeywords.add(recipe.shortcut());
+          }
 
 
-            String lookup = String.join(" ", recipeKeywords);
+          String lookup = String.join(" ", recipeKeywords);
 
-            LookupElementBuilder element = LookupElementBuilder
-                .create(recipe.name())
-                .withTypeText(String.join(",", recipeKeywords))
-                .withLookupString(lookup)
-                .withInsertHandler((insertionContext, lookupElement) -> {
-                    addRecipeInEditor(recipe, indentationCurrentLine, parameters, insertionContext, usesTabs);
-                })
-                .withIcon(CodigaIcons.Codiga_default_icon);
+          LookupElementBuilder element = LookupElementBuilder
+            .create(recipe.name())
+            .withTypeText(String.join(",", recipeKeywords))
+            .withLookupString(lookup)
+            .withInsertHandler((insertionContext, lookupElement) -> {
+              addRecipeInEditor(recipe, indentationCurrentLine, parameters, insertionContext, usesTabs);
+            })
+            .withIcon(CodigaIcons.Codiga_default_icon);
 
 
-
-            result.addElement(element);
+          result.addElement(element);
         }
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApi.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApi.java
@@ -1,5 +1,6 @@
 package io.codiga.plugins.jetbrains.graphql;
 
+import com.intellij.openapi.components.Service;
 import io.codiga.api.*;
 import io.codiga.api.type.LanguageEnumeration;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApiImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApiImpl.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.request.RequestHeaders;
+import com.intellij.openapi.components.Service;
 import io.codiga.api.*;
 import io.codiga.api.type.LanguageEnumeration;
 import io.codiga.plugins.jetbrains.settings.application.AppSettingsState;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/CodingAssistantCodigaTransform.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/CodingAssistantCodigaTransform.java
@@ -27,6 +27,8 @@ public class CodingAssistantCodigaTransform {
       new VariableTransformerDayNameShort());
     VARIABLE_TO_TRANSFORMER.put(CodingAssistantContext.DATE_MONTH_NAME,
       new VariableTransformerMonthName());
+    VARIABLE_TO_TRANSFORMER.put(CodingAssistantContext.DATE_MONTH_NAME_SHORT,
+      new VariableTransformerMonthNameShort());
     VARIABLE_TO_TRANSFORMER.put(CodingAssistantContext.DATE_CURRENT_YEAR,
       new VariableTransformerYear());
     VARIABLE_TO_TRANSFORMER.put(CodingAssistantContext.DATE_CURRENT_YEAR_SHORT,

--- a/src/test/data/completion/spawn_thread.rs
+++ b/src/test/data/completion/spawn_thread.rs
@@ -1,0 +1,2 @@
+spawn <caret>
+

--- a/src/test/data/completion/spawn_thread_accept_result.rs
+++ b/src/test/data/completion/spawn_thread_accept_result.rs
@@ -1,0 +1,6 @@
+use std::thread;
+thread::spawn(move || {
+  // thread code here
+  42
+});
+<caret>

--- a/src/test/data/package-frontend.json
+++ b/src/test/data/package-frontend.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "dev-local": "export REACT_APP_BACKEND_URL=\"http://localhost:5000/graphql\" && react-scripts start",
-    "dev": "export REACT_APP_BACKEND_URL=\"https://dashboard-api.code-inspector.com/graphql\" && react-scripts start",
+    "dev": "export REACT_APP_BACKEND_URL=\"https://dashboard-api.codiga.io/graphql\" && react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/test/data/package-without-dependencies.json
+++ b/src/test/data/package-without-dependencies.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev-local": "export REACT_APP_BACKEND_URL=\"http://localhost:5000/graphql\" && react-scripts start",
-    "dev": "export REACT_APP_BACKEND_URL=\"https://dashboard-api.code-inspector.com/graphql\" && react-scripts start",
+    "dev": "export REACT_APP_BACKEND_URL=\"https://dashboard-api.codiga.io/graphql\" && react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/test/data/transformers/spawn_thread.rs
+++ b/src/test/data/transformers/spawn_thread.rs
@@ -1,0 +1,2 @@
+spawn <caret>
+

--- a/src/test/data/transformers/spawn_thread_indent_result.rs
+++ b/src/test/data/transformers/spawn_thread_indent_result.rs
@@ -1,0 +1,6 @@
+use std::thread;
+thread::spawn(move || {
+    // thread code here
+    42
+});
+<caret>

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroClipboardContentTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroClipboardContentTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroClipboardContentTest extends TestVariableMacroGeneric {
+
+  public void testMacroClipboardContent() {
+    super.performTest(Constants.CLIPBOARD_CONTENT, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileDirTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileDirTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroFileDirTest extends TestVariableMacroGeneric {
+
+  public void testMacroFileDir() {
+    super.performTest(Constants.FILE_DIR, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileNameTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileNameTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroFileNameTest extends TestVariableMacroGeneric {
+
+  public void testMacroFileName() {
+    super.performTest(Constants.FILE_NAME, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileNameWithoutExtensionTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileNameWithoutExtensionTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroFileNameWithoutExtensionTest extends TestVariableMacroGeneric {
+
+  public void testMacroFileNameWithoutExtension() {
+    super.performTest(Constants.FILE_NAME_WITHOUT_EXTENSION, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFilePathTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFilePathTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroFilePathTest extends TestVariableMacroGeneric {
+
+  public void testMacroFilePath() {
+    super.performTest(Constants.FILE_PATH, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileRelativePathTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroFileRelativePathTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroFileRelativePathTest extends TestVariableMacroGeneric {
+
+  public void testMacroFileRelativePath() {
+    super.performTest(Constants.FILE_RELATIVE_PATH, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroLineNumberTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroLineNumberTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroLineNumberTest extends TestVariableMacroGeneric {
+
+  public void testMacroLineNumber() {
+    super.performTest(Constants.LINE_NUMBER, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroProjectFileDirTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroProjectFileDirTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroProjectFileDirTest extends TestVariableMacroGeneric {
+
+  public void testMacroProjectFileDir() {
+    super.performTest(Constants.PROJECT_FILE_DIR, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroProjectNameTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroProjectNameTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroProjectNameTest extends TestVariableMacroGeneric {
+
+  public void testMacroProjectName() {
+    super.performTest(Constants.PROJECT_NAME, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroSelectedTextTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/macros/VariableMacroSelectedTextTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.macros;
+
+import io.codiga.plugins.jetbrains.testutils.Constants;
+import io.codiga.plugins.jetbrains.testutils.TestVariableMacroGeneric;
+
+public class VariableMacroSelectedTextTest extends TestVariableMacroGeneric {
+
+  public void testMacroSelectedText() {
+    super.performTest(Constants.SELECTED_TEXT, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
@@ -1,0 +1,34 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
+
+import java.util.List;
+
+public class VariableIndentationTest extends BasePlatformTestCase {
+
+  @Override
+  protected String getTestDataPath() {
+    String communityPath = PlatformTestUtil.getCommunityPath();
+    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
+    if (communityPath.startsWith(homePath)) {
+      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
+    }
+    return "src/test/data/transformers";
+  }
+
+  public void testIndentation() {
+    myFixture.testCompletionVariants("spawn_thread.rs");
+    myFixture.type("testIndentation");
+    myFixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+
+    myFixture.type('\t');
+    myFixture.checkResultByFile("spawn_thread_indent_result.rs");
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayNameShortTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayNameShortTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerDayNameShortTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerDayNameShort() {
+    super.performTest(CodingAssistantContext.DATE_DAY_NAME_SHORT, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayNameTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayNameTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerDayNameTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerDayName() {
+    super.performTest(CodingAssistantContext.DATE_DAY_NAME, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerDayTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerDayTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerDay() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_DAY, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerHourTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerHourTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerHourTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerHour() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_HOUR, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMinuteTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMinuteTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerMinuteTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerMinute() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_MINUTE, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthNameShortTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthNameShortTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerMonthNameShortTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerMonthNameShort() {
+    super.performTest(CodingAssistantContext.DATE_MONTH_NAME_SHORT, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthNameTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthNameTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerMonthNameTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerMonthName() {
+    super.performTest(CodingAssistantContext.DATE_MONTH_NAME, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthTwoDigitsTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerMonthTwoDigitsTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerMonthTwoDigitsTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerMonthTwoDigits() {
+    super.performTest(CodingAssistantContext.DATE_MONTH_TWO_DIGITS, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumberHexTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumberHexTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerRndNumberHexTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerRndNumberHex() {
+    super.performTest(CodingAssistantContext.RANDOM_BASE_16, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumberTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumberTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerRndNumberTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerRndNumber() {
+    super.performTest(CodingAssistantContext.RANDOM_BASE_10, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerSecondTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerSecond() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_SECOND, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondsUnixTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondsUnixTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerSecondsUnixTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerSecondsUnix() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_SECONDS_UNIX, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerUUIDTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerUUIDTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerUUIDTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerUUID() {
+    super.performTest(CodingAssistantContext.RANDOM_UUID, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearShortTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearShortTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerYearShortTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerYearShort() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_YEAR_SHORT, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerYearTest.java
@@ -1,0 +1,11 @@
+package io.codiga.plugins.jetbrains.assistant.transformers;
+
+import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
+import io.codiga.plugins.jetbrains.testutils.TestVariableTransformerGeneric;
+
+public class VariableTransformerYearTest extends TestVariableTransformerGeneric {
+
+  public void testTransformerYear() {
+    super.performTest(CodingAssistantContext.DATE_CURRENT_YEAR, myFixture);
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
@@ -1,0 +1,57 @@
+package io.codiga.plugins.jetbrains.completion;
+
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+
+import java.util.List;
+
+public class CodigaCompletionProviderTest extends BasePlatformTestCase {
+
+  @Override
+  protected String getTestDataPath() {
+    String communityPath = PlatformTestUtil.getCommunityPath();
+    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
+    if (communityPath.startsWith(homePath)) {
+      return communityPath.substring(homePath.length()) + "src/test/data/completion";
+    }
+    return "src/test/data/completion";
+  }
+
+  public void testOneAutoCompleteSuggestion() {
+    myFixture.testCompletionVariants("spawn_thread.rs");
+    myFixture.type("testOneAutoCompleteSuggestion");
+    myFixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+    assertContainsElements(lookupElementStrings, "Spawn a thread");
+  }
+
+  public void testMultipleAutoCompleteSuggestion() {
+    myFixture.testCompletionVariants("spawn_thread.rs");
+    myFixture.type("testMultipleAutoCompleteSuggestion");
+    myFixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+    assertContainsElements(lookupElementStrings, "Spawn a thread", "Spawn a thread 2");
+    assertDoesntContain(lookupElementStrings, "Spawn a thread 3");
+  }
+
+  public void testAcceptRecipeSuggestion() {
+    myFixture.testCompletionVariants("spawn_thread.rs");
+    myFixture.type("testAcceptRecipeSuggestion");
+    myFixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+
+    myFixture.type('\t');
+    myFixture.checkResultByFile("spawn_thread_accept_result.rs");
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/graphql/CodigaApiTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/graphql/CodigaApiTest.java
@@ -1,10 +1,13 @@
 package io.codiga.plugins.jetbrains.graphql;
 
+import com.apollographql.apollo.api.ResponseField;
 import io.codiga.api.*;
 import io.codiga.api.type.LanguageEnumeration;
 import com.google.common.collect.ImmutableList;
+import io.codiga.plugins.jetbrains.testutils.Constants;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,9 +48,116 @@ public final class CodigaApiTest implements CodigaApi {
         return ImmutableList.of();
     }
 
+    private GetRecipesForClientQuery.GetRecipesForClient generateRecipe(String name,
+                                                                        String jetbrainsFormat,
+                                                                        List<String> keywords,
+                                                                        LanguageEnumeration language) {
+      // typename
+      String typename = "AssistantRecipe";
+      // id
+      int id = 42069;
+      // imports
+      List<String> imports = new ArrayList<>();
+      imports.add("use std::thread;");
+      // description
+      String description = "Quickly spawn a thread using the std library";
+      // shortcut
+      String shortcut = "st";
+
+      return new GetRecipesForClientQuery.GetRecipesForClient(
+        typename,
+        id,
+        name,
+        jetbrainsFormat,
+        jetbrainsFormat,
+        keywords,
+        imports,
+        language,
+        description,
+        shortcut
+      );
+    }
+
     @Override
-    public List<GetRecipesForClientQuery.GetRecipesForClient> getRecipesForClient(List<String> keywords, List<String> dependencies, Optional<String> parameters, LanguageEnumeration language, String filename) {
-        return null;
+    public List<GetRecipesForClientQuery.GetRecipesForClient> getRecipesForClient(List<String> keywords,
+                                                                                  List<String> dependencies,
+                                                                                  Optional<String> parameters,
+                                                                                  LanguageEnumeration language,
+                                                                                  String filename) {
+      List<GetRecipesForClientQuery.GetRecipesForClient> recipes = new ArrayList<>();
+
+      if (keywords.contains("testOneAutoCompleteSuggestion")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          Constants.RECIPE_SAMPLE,
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      if (keywords.contains("testMultipleAutoCompleteSuggestion")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          Constants.RECIPE_SAMPLE,
+          keywords,
+          language));
+        recipes.add(generateRecipe("Spawn a thread 2",
+          Constants.RECIPE_SAMPLE,
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      if (keywords.contains("testAcceptRecipeSuggestion")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          Constants.RECIPE_SAMPLE,
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      // The recipe here only contains `&[CODIGA_INDENT]` transform variable.
+      if (keywords.contains("testIndentation")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          "dGhyZWFkOjpzcGF3bihtb3ZlIHx8IHsKJltDT0RJR0FfSU5ERU5UXS8vIHRocmVhZCBjb2RlIGhlcmUKJltDT0RJR0FfSU5ERU5UXTQyCn0pOw==",
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      /*
+        The recipe in this section contains all the possible Variable Transformations at once,
+        we don't create one recipe per variable.
+
+        It doesn't contain `&[CODIGA_INDENT]`.
+       */
+      if (keywords.contains("testTransformer")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          "dGhyZWFkOjpzcGF3bihtb3ZlIHx8IHsKICAvLyB0aHJlYWQgY29kZSBoZXJlCiAgJltEQVRFX0NVUlJFTlRfREFZXQogICZbREFURV9NT05USF9UV09fRElHSVRTXQogICZbREFURV9DVVJSRU5UX1NFQ09ORF9VTklYXQogICZbREFURV9DVVJSRU5UX1NFQ09ORF0KICAmW0RBVEVfQ1VSUkVOVF9NSU5VVEVdCiAgJltEQVRFX0NVUlJFTlRfSE9VUl0KICAmW0RBVEVfQ1VSUkVOVF9ZRUFSX1NIT1JUXQogICZbREFURV9DVVJSRU5UX1lFQVJdCiAgJltSQU5ET01fQkFTRV8xNl0KICAmW1JBTkRPTV9CQVNFXzEwXQogICZbREFURV9NT05USF9OQU1FX1NIT1JUXQogICZbREFURV9NT05USF9OQU1FXQogICZbREFURV9EQVlfTkFNRV9TSE9SVF0KICAmW0RBVEVfREFZX05BTUVdCiAgJltSQU5ET01fVVVJRF0KfSk7",
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      /*
+        The recipe in this section contains all the possible Variable Macros at once,
+        we don't create one recipe per macro.
+
+        It doesn't contain `&[CODIGA_INDENT]`.
+       */
+      if (keywords.contains("testMacro")) {
+        recipes.add(generateRecipe("Spawn a thread",
+          "dGhyZWFkOjpzcGF3bihtb3ZlIHx8IHsKICAvLyB0aHJlYWQgY29kZSBoZXJlCiAgJFNlbGVjdGVkVGV4dCQKICAkTGluZU51bWJlciQKICAkRmlsZU5hbWUkCiAgJEZpbGVOYW1lV2l0aG91dEV4dGVuc2lvbiQKICAkRmlsZURpciQKICAkRmlsZVBhdGgkCiAgJEZpbGVSZWxhdGl2ZVBhdGgkCiAgJENsaXBib2FyZENvbnRlbnQkCiAgJFByb2plY3ROYW1lJAogICRQcm9qZWN0RmlsZURpciQKfSk7",
+          keywords,
+          language));
+
+        return recipes;
+      }
+
+      return recipes;
     }
 
     public Optional<GetFileDataQuery.Project> getDataForFile(Long projectId, String revision, String path) {

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/Constants.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/Constants.java
@@ -1,0 +1,17 @@
+package io.codiga.plugins.jetbrains.testutils;
+
+public class Constants {
+  // Mocked recipe code to be used in getRecipesForClient() inside CodigaApiTest
+  public final static String RECIPE_SAMPLE = "dGhyZWFkOjpzcGF3bihtb3ZlIHx8IHsKICAvLyB0aHJlYWQgY29kZSBoZXJlCiAgNDIKfSk7";
+
+  public final static String CLIPBOARD_CONTENT = "$ClipboardContent$";
+  public final static String FILE_DIR = "$FileDir$";
+  public final static String FILE_NAME = "$FileName$";
+  public final static String FILE_NAME_WITHOUT_EXTENSION = "$FileNameWithoutExtension$";
+  public final static String FILE_PATH = "$FilePath$";
+  public final static String FILE_RELATIVE_PATH = "$FileRelativePath$";
+  public final static String LINE_NUMBER = "$LineNumber$";
+  public final static String PROJECT_FILE_DIR = "$ProjectFileDir$";
+  public final static String PROJECT_NAME = "$ProjectName$";
+  public final static String SELECTED_TEXT = "$SelectedText$";
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableMacroGeneric.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableMacroGeneric.java
@@ -1,0 +1,56 @@
+package io.codiga.plugins.jetbrains.testutils;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
+import org.junit.Ignore;
+
+import java.util.List;
+
+/**
+ * This Class works as Parent for all the Variable Macro tests, only
+ * `performTest` is being call from the test file passing the variable
+ * of the test and the current myFixture of the running test at the moment.
+ *
+ * This approach prevents extensive code re definition per test file and easier
+ * maintainability. Only to test variables in the format `$_$`.
+ */
+@Ignore
+public class TestVariableMacroGeneric extends BasePlatformTestCase {
+
+  public TestVariableMacroGeneric() {
+    super();
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void performTest(String variable, CodeInsightTestFixture fixture) {
+    fixture.testCompletionVariants("spawn_thread.rs");
+    fixture.type("testMacro");
+    fixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = fixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+
+    fixture.type('\t');
+
+    // We only make sure the Variable Transform is not inside the recipe code to be inserted.
+    // There's no validation about the Variable being expanded to an expected value.
+    assertFalse(fixture.getEditor().getDocument().getText().contains(variable));
+  }
+
+  @Override
+  protected String getTestDataPath() {
+    String communityPath = PlatformTestUtil.getCommunityPath();
+    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
+    if (communityPath.startsWith(homePath)) {
+      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
+    }
+    return "src/test/data/transformers";
+  }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableTransformerGeneric.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableTransformerGeneric.java
@@ -1,0 +1,56 @@
+package io.codiga.plugins.jetbrains.testutils;
+
+import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
+import org.junit.Ignore;
+
+import java.util.List;
+
+/**
+ * This Class works as Parent for all the Variable Transform tests, only
+ * `performTest` is being call from the test file passing the variable
+ * of the test and the current myFixture of the running test at the moment.
+ *
+ * This approach prevents extensive code re definition per test file and easier
+ * maintainability. Only to test variables in the format `&[_]`.
+ */
+@Ignore
+public class TestVariableTransformerGeneric extends BasePlatformTestCase {
+
+  public TestVariableTransformerGeneric() {
+    super();
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+
+  public void performTest(String variable, CodeInsightTestFixture fixture) {
+    fixture.testCompletionVariants("spawn_thread.rs");
+    fixture.type("testTransformer");
+    fixture.complete(CompletionType.BASIC);
+    List<String> lookupElementStrings = fixture.getLookupElementStrings();
+
+    assertNotNull(lookupElementStrings);
+
+    fixture.type('\t');
+
+    // We only make sure the Variable Macro is not inside the recipe code to be inserted.
+    // There's no validation about the Variable being transformed to an expected value.
+    assertFalse(fixture.getEditor().getDocument().getText().contains(variable));
+  }
+
+  @Override
+  protected String getTestDataPath() {
+    String communityPath = PlatformTestUtil.getCommunityPath();
+    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
+    if (communityPath.startsWith(homePath)) {
+      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
+    }
+    return "src/test/data/transformers";
+  }
+}


### PR DESCRIPTION
now we test if variables and macros inside recipes are being transformed using the built-in JetBrains fixture. Tests here include indentation checking too.