### PR TITLE
do not refresh the shortcut cache if there is no user activity

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
@@ -29,7 +29,7 @@ public class SnippetToolWindowFactory implements ToolWindowFactory {
         }
 
         snippetToolWindow = new SnippetToolWindow(toolWindow, project);
-        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        ContentFactory contentFactory = ContentFactory.getInstance();
         Content content = contentFactory.createContent(snippetToolWindow.getContent(), "", false);
         toolWindow.getContentManager().addContent(content);
     }

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
@@ -29,7 +29,7 @@ public class SnippetToolWindowFactory implements ToolWindowFactory {
         }
 
         snippetToolWindow = new SnippetToolWindow(toolWindow, project);
-        ContentFactory contentFactory = ContentFactory.getInstance();
+        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
         Content content = contentFactory.createContent(snippetToolWindow.getContent(), "", false);
         toolWindow.getContentManager().addContent(content);
     }

--- a/src/main/java/io/codiga/plugins/jetbrains/cache/CacheRefreshEditorListener.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/cache/CacheRefreshEditorListener.java
@@ -28,6 +28,9 @@ public class CacheRefreshEditorListener implements FileEditorManagerListener {
     @Override
     public void selectionChanged(@NotNull FileEditorManagerEvent event) {
         FileEditor fileEditor = event.getNewEditor();
+
+        // refresh the last activity timestamp
+        ShortcutCache.getInstance().updateLastActivityTimestamp();
         if (isNotNewFile(fileEditor)) {
             return;
         }

--- a/src/main/java/io/codiga/plugins/jetbrains/cache/ShortcutCache.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/cache/ShortcutCache.java
@@ -70,7 +70,6 @@ public final class ShortcutCache {
      * @param shortcutCacheKey
      */
     private void updateKey(ShortcutCacheKey shortcutCacheKey) {
-        LOGGER.info("refreshing cache key " + shortcutCacheKey.toString());
         Optional<Long> lastUpdateTimestamp = codigaApi.getRecipesForClientByShotcurtLastTimestmap(shortcutCacheKey.getDependencies(), shortcutCacheKey.getLanguage());
         boolean shouldFetch = false;
         if (!lastUpdateTimestamp.isPresent()) {
@@ -129,7 +128,7 @@ public final class ShortcutCache {
             }
 
         } catch (NullPointerException npe) {
-            LOGGER.info("error when refreshing the cache");
+            LOGGER.error("error when refreshing the cache");
         }
     }
 

--- a/src/main/java/io/codiga/plugins/jetbrains/cache/TypedKeyHandler.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/cache/TypedKeyHandler.java
@@ -1,0 +1,22 @@
+package io.codiga.plugins.jetbrains.cache;
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+
+import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
+
+/**
+ * This class just refresh the last actiivty timestamp from the cache so that we
+ * do not refresh the cache when the editor is not active.
+ */
+public class TypedKeyHandler extends TypedHandlerDelegate {
+    public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
+    @Override
+    public Result charTyped(char c, Project project, Editor editor, PsiFile file) {
+        ShortcutCache.getInstance().updateLastActivityTimestamp();
+        return Result.CONTINUE;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -80,6 +80,7 @@
         />
         <errorHandler implementation="io.codiga.plugins.jetbrains.errorreporter.CodigaErrorReporter"/>
 <!--        <statusBarWidgetFactory implementation="com.code_inspector.plugins.intellij.ui.CodeInspectorStatusBar"/>-->
+        <typedHandler implementation="io.codiga.plugins.jetbrains.cache.TypedKeyHandler"/>
     </extensions>
     <projectListeners>
         <listener class="io.codiga.plugins.jetbrains.cache.CacheRefreshEditorListener"


### PR DESCRIPTION
✅ register user activity when the user changes a window or type a character
✅ do not check the cache if there is no user activity after 10 minutes