### PR TITLE
fix: snippet search window

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 pluginGroup = codiga.io.plugins
 pluginName = codiga-jetbrains-plugin
-pluginVersion = 1.7.8
+pluginVersion = 1.7.9
 
 
 pluginSinceBuild = 221.*
 pluginUntilBuild = 222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2021.2, 2021.3, 2022.1
+pluginVerifierIdeVersions = 2021.2, 2021.3, 2022.1, 2022.2
 
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginUntilBuild = 222.*
 pluginVerifierIdeVersions = 2021.2, 2021.3, 2022.1, 2022.2
 
 platformType = IC
-platformVersion = 2022.1
+platformVersion = 2022.2
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFactory.java
@@ -1,8 +1,6 @@
 package io.codiga.plugins.jetbrains.actions.snippet_search;
 
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
@@ -19,22 +17,11 @@ public class SnippetToolWindowFactory implements ToolWindowFactory {
 
 
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
-        // Make sure the current project is set.
-        SnippetToolWindowFileEditorManagerListener.setCurrentProject(project);
-        VirtualFile[] virtualFiles = FileEditorManager.getInstance(project).getSelectedFiles();
-
-        // Make sure we have one virtual file present.
-        if (virtualFiles.length > 0) {
-            SnippetToolWindowFileEditorManagerListener.setCurrentVirtualFile(virtualFiles[0]);
-        }
-
         snippetToolWindow = new SnippetToolWindow(toolWindow, project);
         ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
         Content content = contentFactory.createContent(snippetToolWindow.getContent(), "", false);
         toolWindow.getContentManager().addContent(content);
     }
 
-    public static SnippetToolWindow getSnippetToolWindow() {
-        return snippetToolWindow;
-    }
+
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFileEditorManagerListener.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindowFileEditorManagerListener.java
@@ -2,47 +2,23 @@ package io.codiga.plugins.jetbrains.actions.snippet_search;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
+import io.codiga.plugins.jetbrains.topics.SnippetToolWindowFileChangeNotifier;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
-
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
+import static io.codiga.plugins.jetbrains.topics.SnippetToolWindowFileChangeNotifier.CODIGA_NEW_FILE_SELECTED_TOPIC;
 
 /**
  * This class listens when the editor changes and updates the snippets available
  * in the window toolbar.
  */
 public class SnippetToolWindowFileEditorManagerListener implements FileEditorManagerListener {
-    private static Project currentProject = null;
-    private static VirtualFile currentVirtualFile = null;
-    private static FileEditor currentFileEditor = null;
+
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
-
-    public static Project getCurrentProject() {
-        return currentProject;
-    }
-
-    public static void setCurrentProject(@NotNull Project project) {
-        currentProject = project;
-    }
-
-    public static void setCurrentVirtualFile(@NotNull VirtualFile virtualFile) {
-        currentVirtualFile = virtualFile;
-    }
-
-    public static VirtualFile getCurrentVirtualFile() {
-        return currentVirtualFile;
-    }
-
-    public static FileEditor getCurrentFileEditor() {
-        return currentFileEditor;
-    }
-
+    final SnippetToolWindowFileChangeNotifier newFileTopic =
+        ApplicationManager.getApplication().getMessageBus().syncPublisher(CODIGA_NEW_FILE_SELECTED_TOPIC);
 
     /**
      * This function is triggered every time the user changes the editor.
@@ -50,35 +26,10 @@ public class SnippetToolWindowFileEditorManagerListener implements FileEditorMan
      */
     @Override
     public void selectionChanged(@NotNull FileEditorManagerEvent event) {
-        FileEditor fileEditor = event.getNewEditor();
-        SnippetToolWindow snippetToolWindow = SnippetToolWindowFactory.getSnippetToolWindow();
-
-        // Snippet tool not created or initialize: do not do anything
-        if (snippetToolWindow == null) {
-            return;
-        }
-
-        // there is no new file selected.
-        if (fileEditor == null || fileEditor.getFile() == null) {
-            snippetToolWindow.updateNoEditor();
-            return;
-        }
-
-        snippetToolWindow.setLoading(true);
-        currentProject = event.getManager().getProject();
-        currentVirtualFile = fileEditor.getFile();
-        currentFileEditor = fileEditor;
-
         /**
-         * Execute on pool thread so that we do not block the main thread
-         * and do not cause IntelliJ to hang forever.
+         * Send a message with MessageBus to the snippet search that
+         * we want to refresh the content.
          */
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            snippetToolWindow.updateEditor(
-                    event.getManager().getProject(),
-                    fileEditor.getFile(),
-                    Optional.empty(),
-                    true);
-        });
+        newFileTopic.afterAction(null);
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/use_recipe/UseRecipeSearchModel.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/use_recipe/UseRecipeSearchModel.java
@@ -23,7 +23,7 @@ public class UseRecipeSearchModel implements SearchPopup.Model {
 
     @Override
     public @NotNull String getTitleText() {
-        return "Codiga: Recipe Search";
+        return "Codiga: Snippet Search";
     }
 
     @Override

--- a/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
@@ -154,6 +154,16 @@ public class AppStarter implements StartupActivity {
         AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
+                final AppSettingsState settings = AppSettingsState.getInstance();
+                if (settings == null) {
+                    return;
+                }
+
+                if(!settings.getUseInlineCompletion()) {
+                    LOGGER.debug("do not refresh cache, completion disabled");
+                    return;
+                }
+
                 for(Project project: ProjectManager.getInstance().getOpenProjects()) {
 
                     for(FileEditor fileEditor: FileEditorManager.getInstance(project).getAllEditors()) {

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/SnippetToolWindowFileChangeNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/SnippetToolWindowFileChangeNotifier.java
@@ -1,0 +1,18 @@
+package io.codiga.plugins.jetbrains.topics;
+
+import com.intellij.util.messages.Topic;
+
+/**
+ * Topic that represent what a change of the API key.
+ *
+ * We subscribe to this topic in the preferences when the API key change in order to refresh the list
+ * of projects.
+ */
+public interface SnippetToolWindowFileChangeNotifier {
+
+    Topic<SnippetToolWindowFileChangeNotifier> CODIGA_NEW_FILE_SELECTED_TOPIC =
+        Topic.create("New file selected", SnippetToolWindowFileChangeNotifier.class);
+
+    void beforeAction(Object context);
+    void afterAction(Object context);
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/utils/RecipeUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/RecipeUtils.java
@@ -89,10 +89,12 @@ public final class RecipeUtils {
             template.addVariable(variable);
         }
 
-        TemplateManager.getInstance(project).runTemplate(editor, template);
 
         // Insert all imports
         try {
+            TemplateManager.getInstance(project).runTemplate(editor, template);
+
+
             WriteCommandAction.writeCommandAction(project).run(
                 (ThrowableRunnable<Throwable>) () -> {
                     int firstInsertion = firstPositionToInsert(currentCode, language);


### PR DESCRIPTION
**Problem**

The snippet search is sometimes picking up/editing files that are not in the current window.

**Solution**

When preview or insert a snippet, always take the current window.