### PR TITLE
Deduplication and cleanup regarding TestBase

### DIFF
--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
@@ -1,24 +1,15 @@
 package io.codiga.plugins.jetbrains.assistant.transformers;
 
-
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.PlatformTestUtil;
-import com.intellij.testFramework.fixtures.BasePlatformTestCase;
-import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
 import io.codiga.plugins.jetbrains.settings.application.AppSettingsState;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
 
-public class VariableIndentationTest extends BasePlatformTestCase {
+public class VariableIndentationTest extends TestBase {
 
   @Override
-  protected String getTestDataPath() {
-    String communityPath = PlatformTestUtil.getCommunityPath();
-    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
-    if (communityPath.startsWith(homePath)) {
-      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
-    }
+  protected String getTestDataRelativePath() {
     return "src/test/data/transformers";
   }
-
 
   public void testIndentation() {
     AppSettingsState.getInstance().setUseInlineCompletion(false);

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
@@ -1,23 +1,15 @@
 package io.codiga.plugins.jetbrains.completion;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.PlatformTestUtil;
-import com.intellij.testFramework.fixtures.BasePlatformTestCase;
-import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
 import io.codiga.plugins.jetbrains.settings.application.AppSettingsState;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
 
-public class CodigaCompletionProviderTest extends BasePlatformTestCase {
+public class CodigaCompletionProviderTest extends TestBase {
 
     @Override
-    protected String getTestDataPath() {
-        String communityPath = PlatformTestUtil.getCommunityPath();
-        String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
-        if (communityPath.startsWith(homePath)) {
-            return communityPath.substring(homePath.length()) + "src/test/data/completion";
-        }
+    protected String getTestDataRelativePath() {
         return "src/test/data/completion";
     }
-
 
     public void testAcceptRecipeSuggestion() {
         AppSettingsState.getInstance().setUseInlineCompletion(true);

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
@@ -1,22 +1,15 @@
 package io.codiga.plugins.jetbrains.completion.inline;
 
-import com.intellij.testFramework.PlatformTestUtil;
-import com.intellij.testFramework.fixtures.BasePlatformTestCase;
-import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
 import io.codiga.plugins.jetbrains.settings.application.AppSettingsState;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
 
 /**
  * Integration test for {@link AcceptInlineAction}, {@link ShowNextInlineCompletion} and {@link ShowPreviousInlineCompletion}.
  */
-public class InlineCompletionTest extends BasePlatformTestCase {
+public class InlineCompletionTest extends TestBase {
 
     @Override
-    protected String getTestDataPath() {
-        String communityPath = PlatformTestUtil.getCommunityPath();
-        String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
-        if (communityPath.startsWith(homePath)) {
-            return communityPath.substring(homePath.length()) + "src/test/data/completion/inline";
-        }
+    protected String getTestDataRelativePath() {
         return "src/test/data/completion/inline";
     }
 

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/TestBase.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/TestBase.java
@@ -1,24 +1,18 @@
 package io.codiga.plugins.jetbrains.testutils;
 
+import com.intellij.testFramework.PlatformTestUtil;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
-import org.junit.Ignore;
+import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 
-@Ignore
-public class TestBase extends BasePlatformTestCase {
-
-    public TestBase() {
-        super();
-    }
-
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
+/**
+ * Base test class for integration tests.
+ */
+public abstract class TestBase extends BasePlatformTestCase {
 
     public final String readFile(String path){
         String completePath = this.getTestDataPath() + "/" + path;
@@ -55,6 +49,21 @@ public class TestBase extends BasePlatformTestCase {
 
     @Override
     protected String getTestDataPath() {
+        String communityPath = PlatformTestUtil.getCommunityPath();
+        String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
+        if (communityPath.startsWith(homePath)) {
+            return communityPath.substring(homePath.length()) + getTestDataRelativePath();
+        }
+        return getTestDataRelativePath();
+    }
+
+    /**
+     * Returns the path of the test data folder relative to the project root.
+     * <p>
+     * Override in test classes if you work with another test data folder.
+     */
+    protected String getTestDataRelativePath() {
         return "src/test/data";
     }
+
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableMacroGeneric.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableMacroGeneric.java
@@ -1,11 +1,7 @@
 package io.codiga.plugins.jetbrains.testutils;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.PlatformTestUtil;
-import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
-import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
-import org.junit.Ignore;
 
 import java.util.List;
 
@@ -17,17 +13,7 @@ import java.util.List;
  * This approach prevents extensive code re definition per test file and easier
  * maintainability. Only to test variables in the format `$_$`.
  */
-@Ignore
-public class TestVariableMacroGeneric extends BasePlatformTestCase {
-
-  public TestVariableMacroGeneric() {
-    super();
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
+public abstract class TestVariableMacroGeneric extends TestBase {
 
   public void performTest(String variable, CodeInsightTestFixture fixture) {
     fixture.testCompletionVariants("spawn_thread.rs");
@@ -45,12 +31,8 @@ public class TestVariableMacroGeneric extends BasePlatformTestCase {
   }
 
   @Override
-  protected String getTestDataPath() {
-    String communityPath = PlatformTestUtil.getCommunityPath();
-    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
-    if (communityPath.startsWith(homePath)) {
-      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
-    }
+  protected String getTestDataRelativePath() {
     return "src/test/data/transformers";
   }
+
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableTransformerGeneric.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/testutils/TestVariableTransformerGeneric.java
@@ -1,11 +1,7 @@
 package io.codiga.plugins.jetbrains.testutils;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.PlatformTestUtil;
-import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture;
-import com.intellij.testFramework.fixtures.IdeaTestExecutionPolicy;
-import org.junit.Ignore;
 
 import java.util.List;
 
@@ -17,17 +13,7 @@ import java.util.List;
  * This approach prevents extensive code re definition per test file and easier
  * maintainability. Only to test variables in the format `&[_]`.
  */
-@Ignore
-public class TestVariableTransformerGeneric extends BasePlatformTestCase {
-
-  public TestVariableTransformerGeneric() {
-    super();
-  }
-
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
+public abstract class TestVariableTransformerGeneric extends TestBase {
 
   public void performTest(String variable, CodeInsightTestFixture fixture) {
     fixture.testCompletionVariants("spawn_thread.rs");
@@ -45,12 +31,8 @@ public class TestVariableTransformerGeneric extends BasePlatformTestCase {
   }
 
   @Override
-  protected String getTestDataPath() {
-    String communityPath = PlatformTestUtil.getCommunityPath();
-    String homePath = IdeaTestExecutionPolicy.getHomePathWithPolicy();
-    if (communityPath.startsWith(homePath)) {
-      return communityPath.substring(homePath.length()) + "src/test/data/transformers";
-    }
+  protected String getTestDataRelativePath() {
     return "src/test/data/transformers";
   }
+
 }


### PR DESCRIPTION
### Changes
- Update test data path retrieval logic in `TestBase`.
- Remove `@Ignore` annotation, constructor and `setUp()` from ignored test classes, and make them abstract instead.
- Make some test classes extend `TestBase` to use the new data path retrieval logic.