### PR TITLE
Snippet search syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,12 @@
 
 ## [Unreleased]
 ### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+- [#142](https://github.com/codiga/jetbrains-plugin/issues/142): Added syntax highlighting for the code snippets in the Snippet Search
+  tool window. Currently supported languages are Python and Java.
 
 ## [1.7.16]
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
-- [#150](https://github.com/codiga/jetbrains-plugin/issues/150): Added a missing library dependency and fixed `NoClassDefFoundError`s in some IDEs. 
-
-### Security
+- [#150](https://github.com/codiga/jetbrains-plugin/issues/150): Added a missing library dependency and fixed `NoClassDefFoundError`s in some IDEs.
 
 ## [1.7.15]
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Accept a snippet using either Enter ↩ or Tab ↹. Go through the snippet varia
 
 ## Snippet Search
 
-Use the Codiga Snippets panel on the right to find code snippets that matches your environment.
+Use the Codiga Snippets panel on the right to find code snippets that match your environment.
+
+Syntax highlighting is available for Python and Java snippets.
 
 ![Code Snippet Search](images/snippet-search.gif "Code Snippet Search")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("com.apollographql.apollo") version "2.5.13"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     // UPDATE TO v1.9.1 WHEN IT IS RELEASED TO FIX https://youtrack.jetbrains.com/issue/IDEA-298989/Duplicate-method-name-getFont.
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.6.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,14 @@ pluginSinceBuild=213
 pluginUntilBuild=222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions=2021.2, 2021.3, 2022.1, 2022.2
+pluginVerifierIdeVersions=2021.3, 2022.1, 2022.2
 platformType=IC
-platformVersion=2022.2
+platformVersion=2021.3
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=
+# Python: https://plugins.jetbrains.com/plugin/7322-python-community-edition
+platformPlugins=java,PythonCore:213.5744.223
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetPanel.form
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetPanel.form
@@ -134,29 +134,13 @@
               <editable value="false"/>
             </properties>
           </component>
-          <grid id="eda8f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-            <margin top="0" left="0" bottom="0" right="0"/>
+          <grid id="eda8f" binding="codePanel" layout-manager="BorderLayout" hgap="0" vgap="0">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
-            <children>
-              <component id="2c012" class="javax.swing.JTextArea" binding="code">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="50"/>
-                  </grid>
-                </constraints>
-                <properties>
-                  <editable value="false"/>
-                  <enabled value="true"/>
-                  <focusable value="false"/>
-                  <requestFocusEnabled value="false"/>
-                  <wrapStyleWord value="true"/>
-                </properties>
-              </component>
-            </children>
+            <children/>
           </grid>
         </children>
       </grid>

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetPanel.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetPanel.java
@@ -9,7 +9,6 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.IdeFocusManager;
-import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.ui.EditorTextField;
@@ -66,14 +65,11 @@ public class SnippetPanel {
     private static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
 
     private final CodigaApi codigaApi = ApplicationManager.getApplication().getService(CodigaApi.class);
-    private final ToolWindow toolWindow;
 
     public SnippetPanel(GetRecipesForClientSemanticQuery.AssistantRecipesSemanticSearch snippet,
                         CodeInsertionContext _codeInsertionContext,
-                        ToolWindow toolWindow,
                         Project project) {
         codeInsertionContext = _codeInsertionContext;
-        this.toolWindow = toolWindow;
 
         // The description is in Markdown, we need to decode it into HTML.
         String htmlDescription = Processor.process(snippet.description(), markdownDecorator, true);

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
@@ -397,7 +397,7 @@ public class SnippetToolWindow {
         }
 
         loadingPanel.setVisible(false);
-        snippetsPanel.setVisible(true);
+        snippetsPanel.setVisible(false);
         noEditorPanel.setVisible(false);
 
         fixScrolling(scrollPane);
@@ -406,6 +406,13 @@ public class SnippetToolWindow {
             scrollPane.getViewport().setViewPosition(new Point(0, 0));
             snippetsPanel.revalidate();
             snippetsPanel.repaint();
+            //Notes regarding rendering the code snippet EditorTextFields:
+            //1. Making the snippets panel not visible before repainting, and visible again after it,
+            // helps to render all (not just the first) code snippet fields upon GUI update.
+            //2. 'setVisible()' must be inside 'invokeLater()' and after repainting,
+            // otherwise it'd be called before repaint, and the rendering would be broken.
+            //3. Leave 'SwingUtilities.invokeLater()', using 'Application.invokeLater()' the rendering is broken.
+            snippetsPanel.setVisible(true);
         });
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
@@ -382,7 +382,7 @@ public class SnippetToolWindow {
             codigaApi.getRecipesSemantic(term, dependencies, Optional.empty(), languageEnumeration, filename, visibilityForQuery.getOnlyPublic(), visibilityForQuery.getOnlyPrivate(), visibilityForQuery.getOnlyFavorite());
 
         // Create the snippet panel.
-        List<SnippetPanel> panels = snippets.stream().map(s -> new SnippetPanel(s, codeInsertionContext, toolWindow, project)).collect(Collectors.toList());
+        List<SnippetPanel> panels = snippets.stream().map(s -> new SnippetPanel(s, codeInsertionContext, project)).collect(Collectors.toList());
 
         snippetsPanel.removeAll();
         snippetsPanel.setLayout(new BoxLayout(snippetsPanel, BoxLayout.Y_AXIS));

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/DefaultFileTypeService.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/DefaultFileTypeService.java
@@ -1,0 +1,17 @@
+package io.codiga.plugins.jetbrains.actions.snippet_search.service;
+
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.PlainTextFileType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides plain text file type in case no other language support needed for the snippet search is available.
+ */
+@Service(Service.Level.APP)
+public final class DefaultFileTypeService implements SyntaxHighlightFileTypeService {
+    @Override
+    public @NotNull FileType getFileType() {
+        return PlainTextFileType.INSTANCE;
+    }
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/JavaFileTypeService.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/JavaFileTypeService.java
@@ -1,0 +1,15 @@
+package io.codiga.plugins.jetbrains.actions.snippet_search.service;
+
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.fileTypes.FileType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides Java file type for the syntax highlighting in the snippet search tool window.
+ */
+public class JavaFileTypeService implements SyntaxHighlightFileTypeService {
+    @Override
+    public @NotNull FileType getFileType() {
+        return JavaFileType.INSTANCE;
+    }
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/PythonFileTypeService.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/PythonFileTypeService.java
@@ -1,0 +1,15 @@
+package io.codiga.plugins.jetbrains.actions.snippet_search.service;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.jetbrains.python.PythonFileType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides Python file type for the syntax highlighting in the snippet search tool window.
+ */
+public class PythonFileTypeService implements SyntaxHighlightFileTypeService {
+    @Override
+    public @NotNull FileType getFileType() {
+        return PythonFileType.INSTANCE;
+    }
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/SyntaxHighlightFileTypeService.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/service/SyntaxHighlightFileTypeService.java
@@ -1,0 +1,21 @@
+package io.codiga.plugins.jetbrains.actions.snippet_search.service;
+
+import com.intellij.openapi.fileTypes.FileType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides file type for the snippet search tool window based on which the displayed code snippets are
+ * syntax highlighted.
+ * <p>
+ * This service based file type retrieval logic is put in place to hide the concrete file type classes,
+ * so we don't encounter {@code NoClassDefFoundException}s in case a language support plugin is disabled or
+ * not installed in the IDE.
+ */
+public interface SyntaxHighlightFileTypeService {
+
+    /**
+     * Returns the file type based on which syntax highlighting is applied.
+     */
+    @NotNull
+    FileType getFileType();
+}

--- a/src/main/resources/META-INF/java-features.xml
+++ b/src/main/resources/META-INF/java-features.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService
+                serviceImplementation="io.codiga.plugins.jetbrains.actions.snippet_search.service.JavaFileTypeService"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,6 +50,9 @@
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="java-features.xml">com.intellij.modules.java</depends>
+    <!-- See https://plugins.jetbrains.com/docs/intellij/pycharm.html -->
+    <depends optional="true" config-file="python-features.xml">com.intellij.modules.python</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="Snippet Search" secondary="true" icon="CodigaIcons.Codiga_default_icon" anchor="right"

--- a/src/main/resources/META-INF/python-features.xml
+++ b/src/main/resources/META-INF/python-features.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService
+                serviceImplementation="io.codiga.plugins.jetbrains.actions.snippet_search.service.PythonFileTypeService"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
### Configuration changes
  - Lowered the gradle-intellij-plugin version to 1.6.0 so that the tool window works without encountering the `$$$getFont$$$` issue.
  - Lowered the platform version to 2021.3, so that
    - it matches the `sinceBuild` version,
    - the Python dependency version can be specified properly. It is unclear if the Codiga plugin would run into any errors if the Python plugin version is compatible only with later versions e.g. 2022.2, but the IDE it works in is an earlier one e.g. 2021.3. So this should keep us on the safe side.
  - Removed 2021.2 from the plugin verifier versions, since the Codiga plugin is compatible from 2021.3.

### Code changes
  - Added Java and Python as optional dependencies in `build.gradle.kts` and `plugin.xml`, due to the variety of IDEs the Codiga plugin supports.
  - Replaced the code snippet field with an `EditorTextField` in the `SnippetPanel`. It is configured manually from code, instead of the in the UI designer. Details are in the `SnippetPanel` javadocs.
  - Introduced application services for retrieving `FileType`s.
    - The default service is always available (it is a so-called [light service](https://plugins.jetbrains.com/docs/intellij/plugin-services.html#light-services)), while the Java and Python services are available only when those plugins are installed and enabled. Otherwise the default service (plain text file type) is used.
    - Hiding the `FileType` classes behind services is necessary to prevent `NoClassDefException`s in case a language plugin is not installed, or installed but disabled.

### Notes
- The code snippet field uses the same editor font the user uses.