### PR TITLE
Rosie documentation and code refinement

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
@@ -19,11 +19,9 @@ import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
 
 /**
- * <<<<<<< HEAD
- * This is an [[IntentionAction]] to apply a fix with the series of edit on the code.
- * =======
- * An updated  version of the annotation that contains an offset for JetBrains
- * >>>>>>> 54c6cca7a6fc96154871d929b8d8dbfec6223327
+ * This is an Intention Action to apply a fix with the series of edits on the code.
+ * <p>
+ * It is used and instantiated by {@link RosieAnnotator} via {@link AnnotationBuilder}.
  */
 public class RosieAnnotationFix implements IntentionAction {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
@@ -21,7 +21,7 @@ import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
 /**
  * This is an Intention Action to apply a fix with the series of edits on the code.
  * <p>
- * It is used and instantiated by {@link RosieAnnotator} via {@link AnnotationBuilder}.
+ * It is used and instantiated by {@link RosieAnnotator} via {@link com.intellij.lang.annotation.AnnotationBuilder}.
  */
 public class RosieAnnotationFix implements IntentionAction {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -25,6 +25,9 @@ import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
 import static io.codiga.plugins.jetbrains.ui.UIConstants.ANNOTATION_PREFIX;
 
+/**
+ * Source type for {@code RosieAnnotator#collectInformation()}.
+ */
 class RosieAnnotatorInformation {
     public Project project;
     public PsiFile psiFile;
@@ -37,8 +40,20 @@ class RosieAnnotatorInformation {
     }
 }
 
-public class RosieAnnotator extends com.intellij.lang.annotation.ExternalAnnotator<RosieAnnotatorInformation, List<RosieAnnotationJetBrains>> {
-
+/**
+ * Annotates the current Editor with information returned by the Rosie service,
+ * and when applicable, provides quick fixes for those code violations.
+ * <p>
+ * Type hierarchy of an annotation fix:
+ * <pre>
+ * - {@link RosieAnnotator}
+ *   - {@link RosieAnnotationFix}
+ *     - {@link RosieViolationFix}
+ *       - {@link io.codiga.plugins.jetbrains.model.rosie.RosieViolationFixEdit}
+ *         - {@link io.codiga.plugins.jetbrains.model.rosie.RosiePosition}
+ * </pre>
+ */
+public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation, List<RosieAnnotationJetBrains>> {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private final Rosie rosieService = ApplicationManager.getApplication().getService(Rosie.class);
     private final AppSettingsState settings = AppSettingsState.getInstance();
@@ -111,7 +126,9 @@ public class RosieAnnotator extends com.intellij.lang.annotation.ExternalAnnotat
     }
 
     /**
-     * Generate an annotation for a violation
+     * Generate an annotation for a violation.
+     * <p>
+     * A "fix" for opening the rule information in the browser is always added.
      *
      * @param psiFile    - the file to annotate
      * @param annotation - the annotation we need

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -1,9 +1,9 @@
 package io.codiga.plugins.jetbrains.annotators;
 
-
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.AnnotationBuilder;
 import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.ExternalAnnotator;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -19,11 +19,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
 import static io.codiga.plugins.jetbrains.ui.UIConstants.ANNOTATION_PREFIX;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Source type for {@code RosieAnnotator#collectInformation()}.
@@ -57,7 +57,6 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private final Rosie rosieService = ApplicationManager.getApplication().getService(Rosie.class);
     private final AppSettingsState settings = AppSettingsState.getInstance();
-
 
     /**
      * This function collects all the information at startup (see the doc of the abstract class).
@@ -96,16 +95,9 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
         long startTime = System.currentTimeMillis();
         List<RosieAnnotationJetBrains> annotations = rosieService
             .getAnnotations(rosieAnnotatorInformation.psiFile, rosieAnnotatorInformation.project)
-            .stream().map(annotation -> new RosieAnnotationJetBrains(
-                annotation.getRuleName(),
-                annotation.getMessage(),
-                annotation.getSeverity(),
-                annotation.getCategory(),
-                annotation.getStart(),
-                annotation.getEnd(),
-                annotation.getFixes(),
-                rosieAnnotatorInformation.editor))
-            .collect(Collectors.toList());
+            .stream()
+            .map(annotation -> new RosieAnnotationJetBrains(annotation, rosieAnnotatorInformation.editor))
+            .collect(toList());
         long endTime = System.currentTimeMillis();
         long executionTime = endTime - startTime;
         LOGGER.info(String.format("rosie call time roundtrip: %s", executionTime));

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
@@ -6,6 +6,12 @@ import java.util.List;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 
+/**
+ * Annotation information created by {@link io.codiga.plugins.jetbrains.services.RosieImpl} based on the
+ * information retrieved in {@link RosieResponse} from the Codiga API.
+ *
+ * @see RosieAnnotationJetBrains
+ */
 public class RosieAnnotation {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private final String ruleName;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
@@ -23,20 +23,14 @@ public class RosieAnnotation {
     List<RosieViolationFix> fixes;
 
 
-    public RosieAnnotation(String name,
-                           String message,
-                           String severity,
-                           String category,
-                           RosiePosition positionStart,
-                           RosiePosition positionEnd,
-                           List<RosieViolationFix> fixes) {
+    public RosieAnnotation(String name, RosieViolation violation) {
         this.ruleName = name;
-        this.message = message;
-        this.severity = severity;
-        this.category = category;
-        this.start = positionStart;
-        this.end = positionEnd;
-        this.fixes = fixes;
+        this.message = violation.message;
+        this.severity = violation.severity;
+        this.category = violation.category;
+        this.start = violation.start;
+        this.end = violation.end;
+        this.fixes = violation.fixes;
     }
 
     public String getMessage() {

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
@@ -8,7 +8,11 @@ import java.util.List;
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 
 /**
- * An updated  version of the annotation that contains an offset for JetBrains
+ * An updated version of {@link RosieAnnotation}. It stores the start and end offsets based
+ * on the current Editor. This is used in {@link io.codiga.plugins.jetbrains.annotators.RosieAnnotator}
+ * to provide the annotation information.
+ *
+ * @see RosieAnnotation
  */
 public class RosieAnnotationJetBrains {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
@@ -25,14 +25,14 @@ public class RosieAnnotationJetBrains {
     private String category;
 
 
-    public RosieAnnotationJetBrains(String ruleName, String message, String severity, String category, RosiePosition start, RosiePosition end, List<RosieViolationFix> fixes, Editor editor) {
-        this.ruleName = ruleName;
-        this.message = message;
-        this.severity = severity;
-        this.category = category;
-        this.start = start.getOffset(editor);
-        this.end = end.getOffset(editor);
-        this.fixes = List.copyOf(fixes);
+    public RosieAnnotationJetBrains(RosieAnnotation annotation, Editor editor) {
+        this.ruleName = annotation.getRuleName();
+        this.message = annotation.getMessage();
+        this.severity = annotation.getSeverity();
+        this.category = annotation.getCategory();
+        this.start = annotation.getStart().getOffset(editor);
+        this.end = annotation.getEnd().getOffset(editor);
+        this.fixes = List.copyOf(annotation.getFixes());
     }
 
 

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieConstants.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieConstants.java
@@ -2,14 +2,14 @@ package io.codiga.plugins.jetbrains.model.rosie;
 
 public final class RosieConstants {
 
-    public static String ROSIE_FIX_ADD = "add";
-    public static String ROSIE_FIX_UPDATE = "update";
-    public static String ROSIE_FIX_REMOVE = "remove";
+    public static final String ROSIE_FIX_ADD = "add";
+    public static final String ROSIE_FIX_UPDATE = "update";
+    public static final String ROSIE_FIX_REMOVE = "remove";
 
-    public static String ROSIE_SEVERITY_CRITICAL = "critical";
-    public static String ROSIE_SEVERITY_ERROR = "error";
-    public static String ROSIE_SEVERITY_WARNING = "warning";
-    public static String ROSIE_SEVERITY_INFORMATIONAL = "informational";
+    public static final String ROSIE_SEVERITY_CRITICAL = "critical";
+    public static final String ROSIE_SEVERITY_ERROR = "error";
+    public static final String ROSIE_SEVERITY_WARNING = "warning";
+    public static final String ROSIE_SEVERITY_INFORMATIONAL = "informational";
 
     private RosieConstants() {
         // nothing

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosiePosition.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosiePosition.java
@@ -7,7 +7,10 @@ import org.jetbrains.annotations.NotNull;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 
-public class RosiePosition {
+/**
+ * Represents a position in an editor by its line number and its column number within that line.
+ */
+public final class RosiePosition {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     public int line;
     public int col;
@@ -17,6 +20,11 @@ public class RosiePosition {
         this.col = col;
     }
 
+    /**
+     * Returns the position offset within the Document of the argument Editor.
+     *
+     * @param editor the editor in which the offset is calculated
+     */
     public int getOffset(@NotNull Editor editor) {
         Document document = editor.getDocument();
         int offset = document.getLineStartOffset(this.line - 1) + this.col;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRequest.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRequest.java
@@ -2,11 +2,22 @@ package io.codiga.plugins.jetbrains.model.rosie;
 
 import java.util.List;
 
+/**
+ * Rosie request object sent to the Codiga API.
+ */
 public class RosieRequest {
     public String filename;
-
+    /**
+     * The Rosie language string.
+     * <p>
+     * See {@link io.codiga.plugins.jetbrains.utils.RosieUtils#getRosieLanguage(io.codiga.api.type.LanguageEnumeration)}
+     * and {@link io.codiga.plugins.jetbrains.services.RosieImpl#SUPPORTED_LANGUAGES}.
+     */
     public String language;
     public String fileEncoding;
+    /**
+     * The base64-encoded version of the code to be analysed.
+     */
     public String codeBase64;
     public List<RosieRule> rules;
     public boolean logOutput;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieResponse.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieResponse.java
@@ -2,6 +2,9 @@ package io.codiga.plugins.jetbrains.model.rosie;
 
 import java.util.List;
 
+/**
+ * The Rosie response object returned by the Codiga API.
+ */
 public class RosieResponse {
     public List<RosieRuleResponse> ruleResponses;
     public List<String> errors;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolation.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolation.java
@@ -2,10 +2,22 @@ package io.codiga.plugins.jetbrains.model.rosie;
 
 import java.util.List;
 
+/**
+ * Represents a code violation found by Rosie.
+ */
 public class RosieViolation {
     public String message;
+    /**
+     * The position of the violation from which the annotation begins.
+     */
     public RosiePosition start;
+    /**
+     * The position of the violation at which the annotation ends.
+     */
     public RosiePosition end;
+    /**
+     * See {@code ROSIE_SEVERITY_*} constants in {@link RosieConstants}.
+     */
     public String severity;
     public String category;
     public List<RosieViolationFix> fixes;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFix.java
@@ -2,10 +2,14 @@ package io.codiga.plugins.jetbrains.model.rosie;
 
 import java.util.List;
 
-public class RosieViolationFix {
+/**
+ * Represents a "quick fix" in an editor with one or more potential edits.
+ * <p>
+ * {@link io.codiga.plugins.jetbrains.annotators.RosieAnnotationFix} works based on the information stored here.
+ */
+public final class RosieViolationFix {
     public String description;
     public List<RosieViolationFixEdit> edits;
-
 
     public RosieViolationFix(String description, List<RosieViolationFixEdit> edits) {
         this.description = description;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFixEdit.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFixEdit.java
@@ -1,9 +1,25 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+/**
+ * Represents a single quick fix edit in an Editor.
+ */
 public class RosieViolationFixEdit {
+    /**
+     * The position of the edit from where the fix will begin.
+     */
     public RosiePosition start;
+    /**
+     * The position of the edit at where the fix will end.
+     */
     public RosiePosition end;
+    /**
+     * Content for string insertion and replacement in the editor. Not used for removal edits.
+     */
     public String content;
+    /**
+     * The type of edit to apply. See {@link RosieConstants#ROSIE_FIX_ADD}, {@link RosieConstants#ROSIE_FIX_UPDATE}
+     * and {@link RosieConstants#ROSIE_FIX_REMOVE}.
+     */
     public String editType;
 
 

--- a/src/main/java/io/codiga/plugins/jetbrains/services/Rosie.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/services/Rosie.java
@@ -7,7 +7,19 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Service for retrieving Rosie specific information from the Codiga API.
+ */
 public interface Rosie {
 
-    public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project);
+    /**
+     * Returns the annotations from the Codiga API based on the argument file, based on which code annotation
+     * will be applied in the currently selected and active editor.
+     *
+     * @param psiFile the file to query Rosie information for
+     * @param project the current project
+     * @return the list of Rosie annotations
+     */
+    @NotNull
+    List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
@@ -29,10 +29,10 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.utils.RosieUtils.getRosieLanguage;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Default implementation of the Rosie API.
@@ -150,15 +150,9 @@ public class RosieImpl implements Rosie {
                 RosieResponse rosieResponse = gson.fromJson(result, RosieResponse.class);
                 LOGGER.debug("rosie response: " + rosieResponse);
 
-                annotations = rosieResponse.ruleResponses.stream().flatMap(res -> res.violations.stream().map(violation -> new RosieAnnotation(
-                    res.identifier,
-                    violation.message,
-                    violation.severity,
-                    violation.category,
-                    violation.start,
-                    violation.end,
-                    violation.fixes
-                ))).collect(Collectors.toList());
+                annotations = rosieResponse.ruleResponses.stream()
+                    .flatMap(res -> res.violations.stream().map(violation -> new RosieAnnotation(res.identifier, violation)))
+                    .collect(toList());
             }
             client.close();
             return annotations;

--- a/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
@@ -34,11 +34,18 @@ import java.util.stream.Collectors;
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.utils.RosieUtils.getRosieLanguage;
 
+/**
+ * Default implementation of the Rosie API.
+ */
 public class RosieImpl implements Rosie {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private static final String ROSIE_POST_URL = "https://analysis.codiga.io/analyze";
 
-    // Current supported languages by Rosie
+    /**
+     * Current supported languages by Rosie.
+     * <p>
+     * See also {@link io.codiga.plugins.jetbrains.utils.RosieUtils#getRosieLanguage(LanguageEnumeration)}.
+     */
     private static final List<LanguageEnumeration> SUPPORTED_LANGUAGES = List.of(LanguageEnumeration.PYTHON);
 
     public RosieImpl() {

--- a/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
@@ -109,6 +109,7 @@ public class RosieImpl implements Rosie {
     }
 
     @Override
+    @NotNull
     public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project) {
         List<RosieAnnotation> annotations = List.of();
         Gson gson = new Gson();

--- a/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/services/RosieImpl.java
@@ -1,6 +1,7 @@
 package io.codiga.plugins.jetbrains.services;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.utils.RosieUtils.getRosieLanguage;
@@ -40,6 +42,7 @@ import static java.util.stream.Collectors.toList;
 public class RosieImpl implements Rosie {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private static final String ROSIE_POST_URL = "https://analysis.codiga.io/analyze";
+    private static final Gson GSON = new Gson();
 
     /**
      * Current supported languages by Rosie.
@@ -111,9 +114,6 @@ public class RosieImpl implements Rosie {
     @Override
     @NotNull
     public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project) {
-        List<RosieAnnotation> annotations = List.of();
-        Gson gson = new Gson();
-
         if (psiFile.getVirtualFile() == null) {
             return List.of();
         }
@@ -131,13 +131,13 @@ public class RosieImpl implements Rosie {
             if (rulesString == null) {
                 return List.of();
             }
-            RosieRuleFile rosieRuleFile = gson.fromJson(rulesString, RosieRuleFile.class);
+            RosieRuleFile rosieRuleFile = GSON.fromJson(rulesString, RosieRuleFile.class);
             String codeBase64 = Base64.getEncoder().encodeToString(psiFile.getText().getBytes());
 
-            // Preapare the reqeust
+            // Prepare the request
             RosieRequest request = new RosieRequest(psiFile.getName(), getRosieLanguage(language), "utf8", codeBase64, rosieRuleFile.rules, true);
-            String requestString = gson.toJson(request);
-            StringEntity postingString = new StringEntity(requestString);//gson.tojson() converts your pojo to json
+            String requestString = GSON.toJson(request);
+            StringEntity postingString = new StringEntity(requestString); //gson.toJson() converts your pojo to json
             HttpPost httpPost = new HttpPost(ROSIE_POST_URL);
             httpPost.addHeader("User-Agent", getUserAgent());
             httpPost.addHeader("Content-Type", "application/json");
@@ -145,10 +145,11 @@ public class RosieImpl implements Rosie {
 
             CloseableHttpClient client = HttpClients.createDefault();
             HttpResponse response = client.execute(httpPost);
+            List<RosieAnnotation> annotations = List.of();
             if (response.getEntity() != null) {
 
                 String result = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-                RosieResponse rosieResponse = gson.fromJson(result, RosieResponse.class);
+                RosieResponse rosieResponse = GSON.fromJson(result, RosieResponse.class);
                 LOGGER.debug("rosie response: " + rosieResponse);
 
                 annotations = rosieResponse.ruleResponses.stream()
@@ -160,7 +161,7 @@ public class RosieImpl implements Rosie {
         } catch (IOException unsupportedEncodingException) {
             LOGGER.error("[RosieImpl] ClientProtocolException", unsupportedEncodingException);
             return List.of();
-        } catch (com.google.gson.JsonSyntaxException jsonSyntaxException) {
+        } catch (JsonSyntaxException jsonSyntaxException) {
             LOGGER.error("[RosieImpl] cannot decode JSON", jsonSyntaxException);
             return List.of();
         }

--- a/src/main/java/io/codiga/plugins/jetbrains/utils/RosieUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/RosieUtils.java
@@ -2,13 +2,26 @@ package io.codiga.plugins.jetbrains.utils;
 
 import io.codiga.api.type.LanguageEnumeration;
 
-public class RosieUtils {
-    public static final String getRosieLanguage(LanguageEnumeration language) {
+/**
+ * Utility for the Rosie integration.
+ */
+public final class RosieUtils {
+
+    /**
+     * Returns the Rosie language version String of the argument Codiga language.
+     *
+     * @param language the Codiga language to map to Rosie language
+     */
+    public static String getRosieLanguage(LanguageEnumeration language) {
         switch (language) {
             case PYTHON:
                 return "python";
             default:
                 return "unknown";
         }
+    }
+
+    private RosieUtils() {
+        //Utility class
     }
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
@@ -7,6 +7,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Test service implementation of the Rosie service.
+ */
 public class RosieTest implements Rosie {
     @Override
     public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project) {

--- a/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
@@ -12,6 +12,7 @@ import java.util.List;
  */
 public class RosieTest implements Rosie {
     @Override
+    @NotNull
     public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project) {
         return List.of();
     }


### PR DESCRIPTION
### Changes
- Added javadocs to a handful of Rosie related classes and fields.
- Simplified the constructors of `RosieAnnotation` and `RosieAnnotationJetBrains`, so that less parameters must be passed in.
- Marked the `Rosie#getAnnotations()` method as returning `@NotNull`, as per current implementation details.
- Marked constants in `RosieConstants` final.
- `RosieImpl`
  - Gson is now a static final field.
  - A few other minor adjustments.