### PR TITLE
Rosie integration tests

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
 import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotationJetBrains;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Fix to open the browser to learn more about a violation and a rule.
@@ -49,11 +50,15 @@ public class AnnotationFixOpenBrowser implements IntentionAction {
     @Override
     public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
         try {
-            String urlString = String.format(RULE_DETAILS_URL, rosieAnnotation.getRulesetName(), rosieAnnotation.getRuleName());
-            BrowserUtil.browse(urlString);
+            BrowserUtil.browse(getUrlString());
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @TestOnly
+    String getUrlString() {
+        return String.format(RULE_DETAILS_URL, rosieAnnotation.getRulesetName(), rosieAnnotation.getRuleName());
     }
 
     @Override

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -117,7 +117,7 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
     @Nullable
     private static RosieAnnotationJetBrains convertToAnnotationJetBrains(RosieAnnotation annotation, Editor editor) {
         try {
-            return new RosieAnnotationJetBrains(annotation, annotation.getRulesetName(), editor);
+            return new RosieAnnotationJetBrains(annotation, editor);
         } catch (IndexOutOfBoundsException e) {
             LOGGER.warn(String.format(
                 "[RosieAnnotator] Issue during calculating the line start offset in the editor, for start line %d, or for end line %d.",

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
+import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotation;
 import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotationJetBrains;
 import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFix;
 import io.codiga.plugins.jetbrains.services.Rosie;
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
@@ -96,12 +98,33 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
         List<RosieAnnotationJetBrains> annotations = rosieService
             .getAnnotations(rosieAnnotatorInformation.psiFile, rosieAnnotatorInformation.project)
             .stream()
-            .map(annotation -> new RosieAnnotationJetBrains(annotation, annotation.getRulesetName(), rosieAnnotatorInformation.editor))
+            .map(annotation -> convertToAnnotationJetBrains(annotation, rosieAnnotatorInformation.editor))
+            .filter(Objects::nonNull)
             .collect(toList());
         long endTime = System.currentTimeMillis();
         long executionTime = endTime - startTime;
         LOGGER.info(String.format("rosie call time roundtrip: %s", executionTime));
         return annotations;
+    }
+
+    /**
+     * Converts the argument {@code RosieAnnotation} to {@code RosieAnnotationJetBrains}.
+     * <p>
+     * If there is an {@code IndexOutOfBoundsException} during conversion, specifically when trying to calculate
+     * the line start index in the given editor for a {@code RosiePosition.line} value that is outside the editor's
+     * range, it returns null, so that it can be filtered out.
+     */
+    @Nullable
+    private static RosieAnnotationJetBrains convertToAnnotationJetBrains(RosieAnnotation annotation, Editor editor) {
+        try {
+            return new RosieAnnotationJetBrains(annotation, annotation.getRulesetName(), editor);
+        } catch (IndexOutOfBoundsException e) {
+            LOGGER.warn(String.format(
+                "[RosieAnnotator] Issue during calculating the line start offset in the editor, for start line %d, or for end line %d.",
+                annotation.getStart().line,
+                annotation.getEnd().line));
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotation.java
@@ -1,5 +1,7 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.Getter;
+
 import java.util.List;
 
 /**
@@ -8,6 +10,7 @@ import java.util.List;
  *
  * @see RosieAnnotationJetBrains
  */
+@Getter
 public class RosieAnnotation {
     private final String rulesetName;
     private final String ruleName;
@@ -28,37 +31,5 @@ public class RosieAnnotation {
         this.start = violation.start;
         this.end = violation.end;
         this.fixes = violation.fixes;
-    }
-
-    public String getRulesetName() {
-        return rulesetName;
-    }
-
-    public String getMessage() {
-        return this.message;
-    }
-
-    public String getRuleName() {
-        return this.ruleName;
-    }
-
-    public String getSeverity() {
-        return this.severity;
-    }
-
-    public String getCategory() {
-        return this.category;
-    }
-
-    public RosiePosition getStart() {
-        return this.start;
-    }
-
-    public RosiePosition getEnd() {
-        return this.end;
-    }
-
-    public List<RosieViolationFix> getFixes() {
-        return this.fixes;
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
@@ -24,8 +24,8 @@ public class RosieAnnotationJetBrains {
     private final List<RosieViolationFix> fixes;
 
 
-    public RosieAnnotationJetBrains(RosieAnnotation annotation, String rulesetName, Editor editor) {
-        this.rulesetName = rulesetName;
+    public RosieAnnotationJetBrains(RosieAnnotation annotation, Editor editor) {
+        this.rulesetName = annotation.getRulesetName();
         this.ruleName = annotation.getRuleName();
         this.message = annotation.getMessage();
         this.severity = annotation.getSeverity();

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieAnnotationJetBrains.java
@@ -1,6 +1,7 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
 import com.intellij.openapi.editor.Editor;
+import lombok.Getter;
 
 import java.util.List;
 
@@ -11,6 +12,7 @@ import java.util.List;
  *
  * @see RosieAnnotation
  */
+@Getter
 public class RosieAnnotationJetBrains {
     private final String rulesetName;
     private final String ruleName;
@@ -31,37 +33,5 @@ public class RosieAnnotationJetBrains {
         this.start = annotation.getStart().getOffset(editor);
         this.end = annotation.getEnd().getOffset(editor);
         this.fixes = List.copyOf(annotation.getFixes());
-    }
-
-    public String getRulesetName() {
-        return rulesetName;
-    }
-
-    public String getMessage() {
-        return this.message;
-    }
-
-    public String getRuleName() {
-        return this.ruleName;
-    }
-
-    public String getSeverity() {
-        return this.severity;
-    }
-
-    public String getCategory() {
-        return this.category;
-    }
-
-    public int getStart() {
-        return this.start;
-    }
-
-    public int getEnd() {
-        return this.end;
-    }
-
-    public List<RosieViolationFix> getFixes() {
-        return this.fixes;
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosiePosition.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosiePosition.java
@@ -3,6 +3,7 @@ package io.codiga.plugins.jetbrains.model.rosie;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,15 +13,11 @@ import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
  * Represents a position in an editor by its line number and its column number within that line.
  */
 @EqualsAndHashCode
+@AllArgsConstructor
 public final class RosiePosition {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     public int line;
     public int col;
-
-    public RosiePosition(int line, int col) {
-        this.line = line;
-        this.col = col;
-    }
 
     /**
      * Returns the position offset within the Document of the argument Editor.

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolation.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolation.java
@@ -1,5 +1,6 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
  * Represents a code violation found by Rosie.
  */
 @EqualsAndHashCode
+@AllArgsConstructor
 public class RosieViolation {
     public String message;
     /**
@@ -24,15 +26,4 @@ public class RosieViolation {
     public String severity;
     public String category;
     public List<RosieViolationFix> fixes;
-
-
-    public RosieViolation(RosiePosition start, RosiePosition end, String message, String severity, String category, List<RosieViolationFix> fixes) {
-        this.message = message;
-        this.start = start;
-        this.end = end;
-        this.severity = severity;
-        this.category = category;
-        this.fixes = fixes;
-    }
 }
-

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFixEdit.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFixEdit.java
@@ -1,11 +1,13 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
 /**
  * Represents a single quick fix edit in an Editor.
  */
 @EqualsAndHashCode
+@AllArgsConstructor
 public class RosieViolationFixEdit {
     /**
      * The position of the edit from where the fix will begin.
@@ -24,12 +26,4 @@ public class RosieViolationFixEdit {
      * and {@link RosieConstants#ROSIE_FIX_REMOVE}.
      */
     public String editType;
-
-
-    public RosieViolationFixEdit(RosiePosition start, RosiePosition end, String editType, String content) {
-        this.start = start;
-        this.end = end;
-        this.content = content;
-        this.editType = editType;
-    }
 }

--- a/src/test/data/rosieannotator/highlight_for_multiple_violations.py
+++ b/src/test/data/rosieannotator/highlight_for_multiple_violations.py
@@ -1,0 +1,3 @@
+clas<error descr="critical_violation (Codiga)">s Per</error>son:
+  de<warning descr="error_violation (Codiga)">f __i</warning>nit__(self, name):
+    <weak_warning descr="warning_violation (Codiga)">self.</weak_warning>name = name

--- a/src/test/data/rosieannotator/highlight_for_single_violation.py
+++ b/src/test/data/rosieannotator/highlight_for_single_violation.py
@@ -1,0 +1,3 @@
+clas<weak_warning descr="single_violation (Codiga)">s Per</weak_warning>son:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/data/rosieannotator/no_highlight_for_end_offset_outside.py
+++ b/src/test/data/rosieannotator/no_highlight_for_end_offset_outside.py
@@ -1,0 +1,3 @@
+class <info descr="PY.CLASS_DEFINITION">Person</info>:
+  def <info descr="PY.PREDEFINED_DEFINITION">__init__</info>(<info descr="PY.SELF_PARAMETER">self</info>, <info descr="PY.PARAMETER">name</info>):
+    <info descr="PY.SELF_PARAMETER">self</info>.name = <info descr="PY.PARAMETER">name</info>

--- a/src/test/data/rosieannotator/no_highlight_for_no_violation.py
+++ b/src/test/data/rosieannotator/no_highlight_for_no_violation.py
@@ -1,0 +1,3 @@
+class <info descr="PY.CLASS_DEFINITION">Person</info>:
+  def <info descr="PY.PREDEFINED_DEFINITION">__init__</info>(<info descr="PY.SELF_PARAMETER">self</info>, <info descr="PY.PARAMETER">name</info>):
+    <info descr="PY.SELF_PARAMETER">self</info>.name = <info descr="PY.PARAMETER">name</info>

--- a/src/test/data/rosieannotator/no_highlight_for_start_offset_outside.py
+++ b/src/test/data/rosieannotator/no_highlight_for_start_offset_outside.py
@@ -1,0 +1,3 @@
+class <info descr="PY.CLASS_DEFINITION">Person</info>:
+  def <info descr="PY.PREDEFINED_DEFINITION">__init__</info>(<info descr="PY.SELF_PARAMETER">self</info>, <info descr="PY.PARAMETER">name</info>):
+    <info descr="PY.SELF_PARAMETER">self</info>.name = <info descr="PY.PARAMETER">name</info>

--- a/src/test/data/rosieannotator/text_insertion_fix.py
+++ b/src/test/data/rosieannotator/text_insertion_fix.py
@@ -1,0 +1,3 @@
+class<caret> Person:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/data/rosieannotator/text_removal_fix_ranges_matching.py
+++ b/src/test/data/rosieannotator/text_removal_fix_ranges_matching.py
@@ -1,0 +1,3 @@
+class<caret> Person:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/data/rosieannotator/text_removal_fix_ranges_not_matching.py
+++ b/src/test/data/rosieannotator/text_removal_fix_ranges_not_matching.py
@@ -1,0 +1,3 @@
+class<caret> Person:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/data/rosieannotator/text_replacement_fix_ranges_matching.py
+++ b/src/test/data/rosieannotator/text_replacement_fix_ranges_matching.py
@@ -1,0 +1,3 @@
+class<caret> Person:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/data/rosieannotator/text_replacement_fix_ranges_not_matching.py
+++ b/src/test/data/rosieannotator/text_replacement_fix_ranges_not_matching.py
@@ -1,0 +1,3 @@
+class<caret> Person:
+  def __init__(self, name):
+    self.name = name

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowserTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowserTest.java
@@ -1,0 +1,36 @@
+package io.codiga.plugins.jetbrains.annotators;
+
+import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotation;
+import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotationJetBrains;
+import io.codiga.plugins.jetbrains.model.rosie.RosiePosition;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolation;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+
+import java.util.Collections;
+
+/**
+ * Integration test for {@link AnnotationFixOpenBrowser}.
+ */
+public class AnnotationFixOpenBrowserTest extends TestBase {
+
+    public void testReturnsFormattedRulePageURL() {
+        myFixture.configureByText("open_browser_fix.py",
+            "class Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+        var rosieViolation = new RosieViolation(
+            "open_browser_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "INFORMATIONAL",
+            "CODE_STYLE",
+            Collections.emptyList());
+
+        var rosieAnnotation = new RosieAnnotation("rule-for-open-browser", "custom-ruleset-name", rosieViolation);
+        var rosieAnnotationJetBrains = new RosieAnnotationJetBrains(rosieAnnotation, myFixture.getEditor());
+
+        String urlString = new AnnotationFixOpenBrowser(rosieAnnotationJetBrains).getUrlString();
+
+        assertEquals("https://app.codiga.io/hub/ruleset/custom-ruleset-name/rule-for-open-browser", urlString);
+    }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
@@ -1,0 +1,98 @@
+package io.codiga.plugins.jetbrains.annotators;
+
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+
+/**
+ * Integration test for {@link RosieAnnotator}.
+ */
+public class RosieAnnotatorTest extends TestBase {
+
+    @Override
+    protected String getTestDataRelativePath() {
+        return TEST_DATA_BASE_PATH + "/rosieannotator";
+    }
+
+    //Positive cases
+
+    public void testNoHighlightForNoViolation() {
+        doTestAnnotations("no_highlight_for_no_violation.py");
+    }
+
+    public void testHighlightForSingleViolation() {
+        doTestAnnotations("highlight_for_single_violation.py", false, false, true);
+    }
+
+    public void testHighlightForMultipleViolations() {
+        doTestAnnotations("highlight_for_multiple_violations.py", true, false, true);
+    }
+
+    public void testTextInsertionFix() {
+        doTestAnnotationFixes("text_insertion_fix.py", "Fix: Insert text",
+            "clasThis is the inserted texts Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextReplacementFixWithEditRangeMatchingViolationRange() {
+        doTestAnnotationFixes("text_replacement_fix_ranges_matching.py", "Fix: Replace text",
+            "clasThis is the replacment textson:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextReplacementFixWithEditRangeNotMatchingViolationRange() {
+        doTestAnnotationFixes("text_replacement_fix_ranges_not_matching.py", "Fix: Replace text",
+            "cThis is the replacement texts Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextRemovalFixWithEditRangeMatchingViolationRange() {
+        doTestAnnotationFixes("text_removal_fix_ranges_matching.py", "Fix: Remove text",
+            "classon:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextRemovalFixWithEditRangeNotMatchingViolationRange() {
+        doTestAnnotationFixes("text_removal_fix_ranges_not_matching.py", "Fix: Remove text",
+            "cs Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    //Negative cases
+
+    public void testNoHighlightWhenFileRangeDoesntContainAnnotationStartOffset() {
+        doTestAnnotations("no_highlight_for_start_offset_outside.py");
+    }
+
+    public void testNoHighlightWhenFileRangeDoesntContainAnnotationEndOffset() {
+        doTestAnnotations("no_highlight_for_end_offset_outside.py");
+    }
+
+    //Helpers
+
+    /**
+     * Note: there is an issue on platform-level with using info-level checks,
+     * when there are actual annotations in the file. That is why it is turned off in some tests.
+     * <p>
+     * Note 2: info-level checks is enabled for no-highlight test cases to completely make sure that no Rosie related
+     * annotations are added in the test file.
+     */
+    private void doTestAnnotations(String filePath, boolean checkWarnings, boolean checkInfos, boolean checkWeakWarnings) {
+        myFixture.configureByFile(filePath);
+        myFixture.testHighlighting(checkWarnings, checkInfos, checkWeakWarnings);
+    }
+
+    private void doTestAnnotations(String filePath) {
+        doTestAnnotations(filePath, true, true, true);
+    }
+
+    private void doTestAnnotationFixes(String filePath, String fixName, String afterText) {
+        myFixture.configureByFile(filePath);
+        myFixture.doHighlighting();
+        myFixture.launchAction(myFixture.findSingleIntention(fixName));
+        myFixture.checkResult(afterText);
+    }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/services/RosieTest.java
@@ -3,17 +3,215 @@ package io.codiga.plugins.jetbrains.services;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import io.codiga.plugins.jetbrains.model.rosie.RosieAnnotation;
+import io.codiga.plugins.jetbrains.model.rosie.RosiePosition;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolation;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFix;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFixEdit;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Test service implementation of the Rosie service.
  */
 public class RosieTest implements Rosie {
+
     @Override
     @NotNull
     public List<RosieAnnotation> getAnnotations(@NotNull PsiFile psiFile, @NotNull Project project) {
-        return List.of();
+        switch (psiFile.getName()) {
+            case "no_highlight_for_no_violation.py":
+                return List.of();
+            case "highlight_for_single_violation.py":
+                return singleViolation();
+            case "highlight_for_multiple_violations.py":
+                return multipleViolations();
+            case "text_insertion_fix.py":
+                return textInsertionFix();
+            case "text_replacement_fix_ranges_matching.py":
+                return textReplaceRangesMatching();
+            case "text_replacement_fix_ranges_not_matching.py":
+                return textReplaceRangesNotMatching();
+            case "text_removal_fix_ranges_matching.py":
+                return textRemoveRangesMatching();
+            case "text_removal_fix_ranges_not_matching.py":
+                return textRemoveRangesNotMatching();
+            case "no_highlight_for_start_offset_outside.py":
+                return startOffsetOutside();
+            case "no_highlight_for_end_offset_outside.py":
+                return endOffsetOutside();
+            default:
+                return List.of();
+        }
+    }
+
+    private List<RosieAnnotation> singleViolation() {
+        var rosieViolation = new RosieViolation(
+            "single_violation",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "INFORMATIONAL",
+            "CODE_STYLE",
+            Collections.emptyList());
+
+        return List.of(new RosieAnnotation("single_rule", "single_ruleset", rosieViolation));
+    }
+
+    /**
+     * Also includes test cases for different severity/highlight levels.
+     */
+    private List<RosieAnnotation> multipleViolations() {
+        var rosieViolationCritical = new RosieViolation(
+            "critical_violation",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "CRITICAL",
+            "ERROR_PRONE",
+            Collections.emptyList());
+        var rosieViolationError = new RosieViolation(
+            "error_violation",
+            new RosiePosition(2, 5),
+            new RosiePosition(2, 10),
+            "ERROR",
+            "SAFETY",
+            Collections.emptyList());
+        var rosieViolationWarning = new RosieViolation(
+            "warning_violation",
+            new RosiePosition(3, 5),
+            new RosiePosition(3, 10),
+            "WARNING",
+            "BEST_PRACTICE",
+            Collections.emptyList());
+
+        return List.of(
+            new RosieAnnotation("critical_rule", "ruleset_name", rosieViolationCritical),
+            new RosieAnnotation("error_rule", "ruleset_name", rosieViolationError),
+            new RosieAnnotation("warning_rule", "ruleset_name", rosieViolationWarning)
+        );
+    }
+
+    private List<RosieAnnotation> textInsertionFix() {
+        var rosieViolationFix = new RosieViolationFix(
+            "Insert text",
+            List.of(
+                new RosieViolationFixEdit(
+                    new RosiePosition(1, 5),
+                    new RosiePosition(1, 10),
+                    "This is the inserted text",
+                    "add")));
+        var rosieViolation = new RosieViolation(
+            "has_text_insertion_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            List.of(rosieViolationFix));
+
+        return List.of(new RosieAnnotation("text_insertion_rule", "text_insertion_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> textReplaceRangesMatching() {
+        var rosieViolationFix = new RosieViolationFix(
+            "Replace text",
+            List.of(
+                new RosieViolationFixEdit(
+                    new RosiePosition(1, 5),
+                    new RosiePosition(1, 10),
+                    "This is the replacment text",
+                    "update")));
+        var rosieViolation = new RosieViolation(
+            "has_text_replace_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            List.of(rosieViolationFix));
+
+        return List.of(new RosieAnnotation("text_replacement_rule", "text_replacement_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> textReplaceRangesNotMatching() {
+        var rosieViolationFix = new RosieViolationFix(
+            "Replace text",
+            List.of(
+                new RosieViolationFixEdit(
+                    new RosiePosition(1, 2),
+                    new RosiePosition(1, 5),
+                    "This is the replacement text",
+                    "update")));
+        var rosieViolation = new RosieViolation(
+            "has_text_replace_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            List.of(rosieViolationFix));
+
+        return List.of(new RosieAnnotation("text_replacement_rule", "text_replacement_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> textRemoveRangesMatching() {
+        var rosieViolationFix = new RosieViolationFix(
+            "Remove text",
+            List.of(
+                new RosieViolationFixEdit(
+                    new RosiePosition(1, 5),
+                    new RosiePosition(1, 10),
+                    "Unused removal text",
+                    "remove")));
+        var rosieViolation = new RosieViolation(
+            "has_text_remove_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            List.of(rosieViolationFix));
+
+        return List.of(new RosieAnnotation("text_remove_rule", "text_remove_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> textRemoveRangesNotMatching() {
+        var rosieViolationFix = new RosieViolationFix(
+            "Remove text",
+            List.of(
+                new RosieViolationFixEdit(
+                    new RosiePosition(1, 2),
+                    new RosiePosition(1, 5),
+                    "Unused removal text",
+                    "remove")));
+        var rosieViolation = new RosieViolation(
+            "has_text_remove_fix",
+            new RosiePosition(1, 5),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            List.of(rosieViolationFix));
+
+        return List.of(new RosieAnnotation("text_remove_rule", "text_remove_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> startOffsetOutside() {
+        var rosieViolation = new RosieViolation(
+            "start_offset_outside",
+            new RosiePosition(5, 15),
+            new RosiePosition(1, 10),
+            "WARNING",
+            "CODE_STYLE",
+            Collections.emptyList());
+
+        return List.of(new RosieAnnotation("start_offset_rule", "start_offset_ruleset", rosieViolation));
+    }
+
+    private List<RosieAnnotation> endOffsetOutside() {
+        var rosieViolation = new RosieViolation(
+            "end_offset_outside",
+            new RosiePosition(1, 5),
+            new RosiePosition(5, 10),
+            "WARNING",
+            "CODE_STYLE",
+            Collections.emptyList());
+
+        return List.of(new RosieAnnotation("start_offset_rule", "start_offset_ruleset", rosieViolation));
     }
 }


### PR DESCRIPTION
### Changes
- Simplified a few classes using Lombok.
- `RosieAnnotator`
  - Added integration tests.
  - Filtered out annotations in which the line start offset in the editor can't be calculated due to out-of-range, start or end line offset received from the server.
- Added integration tests for `AnnotationFixOpenBrowser`.
- Simplfied the constructor of `RosieAnnotationJetBrains`.