### PR TITLE
Rosie rules cache updater tests

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCache.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCache.java
@@ -8,6 +8,7 @@ import io.codiga.api.type.LanguageEnumeration;
 import io.codiga.plugins.jetbrains.annotators.RosieRulesCacheValue.RuleWithNames;
 import io.codiga.plugins.jetbrains.model.rosie.RosieRule;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 import org.jetbrains.yaml.psi.YAMLFile;
 
 import java.util.List;
@@ -41,12 +42,12 @@ public final class RosieRulesCache implements Disposable {
     /**
      * The timestamp of the last update on the Codiga server for the rulesets cached (and configured in codiga.yml).
      */
-    private long lastUpdatedTimeStamp;
+    private long lastUpdatedTimeStamp = -1L;
     /**
      * -1 means the modification stamp of codiga.yml hasn't been set,
      * or there is no codiga.yml file in the project root.
      */
-    private long configFileModificationStamp = -1;
+    private long configFileModificationStamp = 0L;
 
     public RosieRulesCache(Project project) {
         this.cache = new ConcurrentHashMap<>();
@@ -120,9 +121,9 @@ public final class RosieRulesCache implements Disposable {
      */
     public void clear() {
         if (!cache.isEmpty()) {
-            configFileModificationStamp = -1;
             cache.clear();
         }
+        lastUpdatedTimeStamp = -1L;
     }
 
     @Override
@@ -132,5 +133,20 @@ public final class RosieRulesCache implements Disposable {
 
     public static RosieRulesCache getInstance(@NotNull Project project) {
         return project.getService(RosieRulesCache.class);
+    }
+
+    @TestOnly
+    public boolean isEmpty() {
+        return cache.isEmpty();
+    }
+
+    @TestOnly
+    public long getConfigFileModificationStamp() {
+        return configFileModificationStamp;
+    }
+
+    @TestOnly
+    public void setConfigFileModificationStamp(long configFileModificationStamp) {
+        this.configFileModificationStamp = configFileModificationStamp;
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandler.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandler.java
@@ -1,0 +1,100 @@
+package io.codiga.plugins.jetbrains.starter;
+
+import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
+import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.collectRulesetNames;
+import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.findCodigaConfigFile;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import io.codiga.plugins.jetbrains.annotators.RosieRulesCache;
+import io.codiga.plugins.jetbrains.graphql.CodigaApi;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.yaml.psi.YAMLFile;
+
+/**
+ * Handles updating the {@link RosieRulesCache}. This is executed periodically via {@link RosieRulesCacheUpdater}.
+ */
+@RequiredArgsConstructor
+public final class RosieRulesCacheUpdateHandler {
+    public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
+    private final CodigaApi codigaApi = CodigaApi.getInstance();
+    private final RosieRulesCache rulesCache;
+    private final Project project;
+
+    public void handleCacheUpdate() {
+        if (project.isDisposed()) {
+            return;
+        }
+
+        YAMLFile codigaConfigFile = findCodigaConfigFile(project);
+        if (codigaConfigFile == null
+            //While the PsiFile may still exist, the underlying VirtualFile may not be valid, or exist at all
+            || !codigaConfigFile.getVirtualFile().isValid()
+            || !codigaConfigFile.getVirtualFile().exists()) {
+            rulesCache.clear();
+            //Since the config file no longer exist, its modification stamp is reset too
+            rulesCache.setConfigFileModificationStamp(0);
+            return;
+        }
+
+        if (rulesCache.hasDifferentModificationStampThan(codigaConfigFile)) {
+            updateCacheFromModifiedCodigaConfigFile(codigaConfigFile);
+        } else {
+            updateCacheFromChangesOnServer(codigaConfigFile);
+        }
+    }
+
+    //There was a change in the codiga.yml file
+    private void updateCacheFromModifiedCodigaConfigFile(YAMLFile codigaConfigFile) {
+        rulesCache.saveModificationStampOf(codigaConfigFile);
+        var rulesetNames = collectRulesetNames(codigaConfigFile);
+
+        //Since there was a config change locally, and there is at least one ruleset name configured,
+        // query to the Codiga server must be sent.
+        if (!rulesetNames.isEmpty()) {
+            codigaApi.getRulesetsForClient(rulesetNames).ifPresent(rulesets -> {
+                /*
+                  If the server returns no rulesets, e.g. due to misconfiguration of codiga.yml,
+                  we clear the cache. NOTE: this doesn't take into account if no ruleset is returned
+                  due to an issue in how the Codiga server collects the rules.
+                 */
+                if (rulesets.isEmpty()) {
+                    rulesCache.clear();
+                    return;
+                }
+
+                rulesCache.updateCacheFrom(rulesets);
+                /*
+                  Updating the local timestamp only if it has changed, because it may happen that
+                  codiga.yml was updated locally with a non-existent ruleset, or a ruleset that has an earlier timestamp,
+                  than the latest updated one, so the rulesets configured don't result in an updated timestamp from the server.
+                 */
+                codigaApi.getRulesetsLastTimestamp(rulesetNames)
+                    .filter(timestamp -> timestamp != rulesCache.getLastUpdatedTimeStamp())
+                    .ifPresent(rulesCache::setLastUpdatedTimeStamp);
+            });
+        } else {
+            rulesCache.clear();
+        }
+    }
+
+    //The codiga.yml file is unchanged
+    private void updateCacheFromChangesOnServer(YAMLFile codigaConfigFile) {
+        var rulesetNames = collectRulesetNames(codigaConfigFile);
+        if (!rulesetNames.isEmpty()) {
+            /*
+              If any of the rulesets have changed on the Codiga server, compared to what we have in the local cache,
+              update the cache.
+              If only non-existent ruleset names are sent, Optional.empty() is returned, thus no cache update happens.
+             */
+            codigaApi.getRulesetsLastTimestamp(rulesetNames)
+                .filter(timestamp -> timestamp != rulesCache.getLastUpdatedTimeStamp())
+                .ifPresent(timestamp ->
+                    codigaApi.getRulesetsForClient(rulesetNames).ifPresent(rulesets -> {
+                        rulesCache.updateCacheFrom(rulesets);
+                        rulesCache.setLastUpdatedTimeStamp(timestamp);
+                        LOGGER.debug("[RosieRulesCacheUpdateHandler] Updated rulesets and timestamp in local Rosie cache for project: " + project.getName());
+                    }));
+        }
+    }
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdater.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdater.java
@@ -47,7 +47,6 @@ public class RosieRulesCacheUpdater implements StartupActivity {
      * Starts the updater for the {@link RosieRulesCache}.
      */
     private void startRosieRulesCacheUpdater(@NotNull Project project) {
-        LOGGER.warn("[RosieRulesCacheUpdater] Starting Rosie rules cache updater");
         var updateHandler = new RosieRulesCacheUpdateHandler(RosieRulesCache.getInstance(project), project);
         var cacheUpdater = AppExecutorUtil.getAppScheduledExecutorService()
             .scheduleWithFixedDelay(updateHandler::handleCacheUpdate, 1L, 10L, SECONDS);

--- a/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdater.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdater.java
@@ -1,8 +1,6 @@
 package io.codiga.plugins.jetbrains.starter;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
-import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.collectRulesetNames;
-import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.findCodigaConfigFile;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -14,9 +12,7 @@ import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import io.codiga.plugins.jetbrains.annotators.RosieRulesCache;
-import io.codiga.plugins.jetbrains.graphql.CodigaApi;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.yaml.psi.YAMLFile;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,7 +27,6 @@ import java.util.concurrent.ScheduledFuture;
 public class RosieRulesCacheUpdater implements StartupActivity {
 
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
-    private final CodigaApi codigaApi = CodigaApi.getInstance();
 
     /**
      * Stores the Rosie cache updaters per project, so that they can be properly cancelled upon project close.
@@ -43,69 +38,19 @@ public class RosieRulesCacheUpdater implements StartupActivity {
 
     @Override
     public void runActivity(@NotNull Project project) {
-        startRosieRulesCacheUpdater(project);
+        if (!ApplicationManager.getApplication().isUnitTestMode()) {
+            startRosieRulesCacheUpdater(project);
+        }
     }
 
     /**
      * Starts the updater for the {@link RosieRulesCache}.
      */
     private void startRosieRulesCacheUpdater(@NotNull Project project) {
-        var rulesCache = RosieRulesCache.getInstance(project);
-        var cacheUpdater = AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(() -> {
-            if (project.isDisposed()) {
-                return;
-            }
-
-            YAMLFile codigaConfigFile = findCodigaConfigFile(project);
-            if (codigaConfigFile == null) {
-                rulesCache.clear();
-                return;
-            }
-
-            //There was a change in the codiga.yml file
-            if (rulesCache.hasDifferentModificationStampThan(codigaConfigFile)) {
-                rulesCache.saveModificationStampOf(codigaConfigFile);
-                var rulesetNames = collectRulesetNames(codigaConfigFile);
-
-                //Since there was a config change locally, and there is at least one ruleset name configured,
-                // query to the Codiga server must be sent
-                if (!rulesetNames.isEmpty()) {
-                    codigaApi.getRulesetsForClient(rulesetNames).ifPresent(rulesets -> {
-                        rulesCache.updateCacheFrom(rulesets);
-
-                        /*
-                          Updating the local timestamp only if it has changed, because it may happen that
-                          codiga.yml was updated locally with a non-existent ruleset, or a ruleset that has an earlier timestamp,
-                          than the latest updated one, so the rulesets configured don't result in an updated timestamp from the server.
-                         */
-                        codigaApi.getRulesetsLastTimestamp(rulesetNames)
-                            .filter(timestamp -> timestamp != rulesCache.getLastUpdatedTimeStamp())
-                            .ifPresent(rulesCache::setLastUpdatedTimeStamp);
-                    });
-                } else {
-                    rulesCache.clear();
-                }
-            }
-            //The codiga.yml file is unchanged
-            else {
-                var rulesetNames = collectRulesetNames(codigaConfigFile);
-                if (!rulesetNames.isEmpty()) {
-                    /*
-                      If any of the rulesets have changed on the Codiga server, compared to what we have in the local cache,
-                      update the cache.
-                      If only non-existent ruleset names are sent, Optional.empty() is returned, thus no cache update happens.
-                     */
-                    codigaApi.getRulesetsLastTimestamp(rulesetNames)
-                        .filter(timestamp -> timestamp != rulesCache.getLastUpdatedTimeStamp())
-                        .ifPresent(timestamp ->
-                            codigaApi.getRulesetsForClient(rulesetNames).ifPresent(rulesets -> {
-                                rulesCache.updateCacheFrom(rulesets);
-                                rulesCache.setLastUpdatedTimeStamp(timestamp);
-                                LOGGER.debug("[RosieRulesCacheUpdater] Updated rulesets and timestamp in local Rosie cache for project: " + project.getName());
-                            }));
-                }
-            }
-        }, 1L, 10L, SECONDS);
+        LOGGER.warn("[RosieRulesCacheUpdater] Starting Rosie rules cache updater");
+        var updateHandler = new RosieRulesCacheUpdateHandler(RosieRulesCache.getInstance(project), project);
+        var cacheUpdater = AppExecutorUtil.getAppScheduledExecutorService()
+            .scheduleWithFixedDelay(updateHandler::handleCacheUpdate, 1L, 10L, SECONDS);
 
         rosieCacheUpdaters.put(project, cacheUpdater);
 

--- a/src/test/data/rosiecacheupdater/codiga.yml
+++ b/src/test/data/rosiecacheupdater/codiga.yml
@@ -1,0 +1,2 @@
+rulesets:
+  - singleRulesetSingleLanguage

--- a/src/test/data/rosiecacheupdater/noruleset/codiga.yml
+++ b/src/test/data/rosiecacheupdater/noruleset/codiga.yml
@@ -1,0 +1,1 @@
+rulesets:

--- a/src/test/java/io/codiga/plugins/jetbrains/graphql/CodigaApiTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/graphql/CodigaApiTest.java
@@ -232,7 +232,7 @@ public final class CodigaApiTest implements CodigaApi {
 
     @Override
     public Optional<Long> getRulesetsLastTimestamp(List<String> ruleNames) {
-        return Optional.empty();
+        return RulesetsForClientTestSupport.getRulesetsLastTimestamp(ruleNames);
     }
 
     @Override

--- a/src/test/java/io/codiga/plugins/jetbrains/graphql/RulesetsForClientTestSupport.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/graphql/RulesetsForClientTestSupport.java
@@ -50,10 +50,14 @@ public final class RulesetsForClientTestSupport {
      */
     public static Optional<List<GetRulesetsForClientQuery.RuleSetsForClient>> getRulesetsForClient(List<String> rulesetNames) {
         List<GetRulesetsForClientQuery.RuleSetsForClient> rulesets;
+        if (rulesetNames.isEmpty()) {
+            return Optional.of(List.of());
+        }
         switch (rulesetNames.get(0)) {
             case "singleRulesetSingleLanguage":
                 rulesets = singleRulesetSingleLanguage(); //Python
                 break;
+            case "singleRulesetMultipleLanguagesDefaultTimestamp":
             case "singleRulesetMultipleLanguages":
                 rulesets = singleRulesetMultipleLanguages(); //Python, Java
                 break;
@@ -63,16 +67,36 @@ public final class RulesetsForClientTestSupport {
             case "multipleRulesetsMultipleLanguages":
                 rulesets = multipleRulesetsMultipleLanguages(); //Python, Java
                 break;
+            case "erroredRuleset":
+                rulesets = null;
+                break;
             default:
                 rulesets = List.of();
         }
-        return Optional.of(rulesets);
+        return Optional.ofNullable(rulesets);
+    }
+
+    public static Optional<Long> getRulesetsLastTimestamp(List<String> rulesetNames) {
+        switch (rulesetNames.get(0)) {
+            case "singleRulesetSingleLanguage":
+                return Optional.of(101L);
+            case "singleRulesetMultipleLanguagesDefaultTimestamp":
+                return Optional.of(100L);
+            case "singleRulesetMultipleLanguages":
+                return Optional.of(102L);
+            case "multipleRulesetsSingleLanguage":
+                return Optional.of(103L);
+            case "multipleRulesetsMultipleLanguages":
+                return Optional.of(104L);
+            default:
+                return Optional.empty();
+        }
     }
 
     /**
      * Returns a single ruleset with a few rules, all configured for the same language.
      */
-    private static List<GetRulesetsForClientQuery.RuleSetsForClient> singleRulesetSingleLanguage() {
+    public static List<GetRulesetsForClientQuery.RuleSetsForClient> singleRulesetSingleLanguage() {
         var rules = List.of(PYTHON_RULE_1, PYTHON_RULE_2, PYTHON_RULE_3);
 
         var ruleset = new GetRulesetsForClientQuery.RuleSetsForClient("typename", 1234, "python-ruleset", rules);
@@ -83,7 +107,7 @@ public final class RulesetsForClientTestSupport {
     /**
      * Returns a single ruleset with a few rules configured for different languages.
      */
-    private static List<GetRulesetsForClientQuery.RuleSetsForClient> singleRulesetMultipleLanguages() {
+    public static List<GetRulesetsForClientQuery.RuleSetsForClient> singleRulesetMultipleLanguages() {
         var rules = List.of(PYTHON_RULE_1, JAVA_RULE_1, PYTHON_RULE_3);
 
         var ruleset = new GetRulesetsForClientQuery.RuleSetsForClient("typename", 2345, "mixed-ruleset", rules);

--- a/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerNoRulesetTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerNoRulesetTest.java
@@ -1,0 +1,29 @@
+package io.codiga.plugins.jetbrains.starter;
+
+import io.codiga.plugins.jetbrains.annotators.RosieRulesCache;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+
+/**
+ * Integration test for {@link RosieRulesCacheUpdateHandler}.
+ */
+public class RosieRulesCacheUpdateHandlerNoRulesetTest extends TestBase {
+
+    @Override
+    protected String getTestDataRelativePath() {
+        return TEST_DATA_BASE_PATH + "/rosiecacheupdater/noruleset";
+    }
+
+    public void testDoesntUpdateCacheIfNoRulesetNameIsConfigured() {
+        myFixture.copyFileToProject("codiga.yml");
+        RosieRulesCache rulesCache = RosieRulesCache.getInstance(getProject());
+
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        validateThatCacheIsEmpty(rulesCache);
+    }
+
+    protected static void validateThatCacheIsEmpty(RosieRulesCache rulesCache) {
+        assertTrue(rulesCache.isEmpty());
+        assertEquals(-1, rulesCache.getLastUpdatedTimeStamp());
+    }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerTest.java
@@ -1,0 +1,205 @@
+package io.codiga.plugins.jetbrains.starter;
+
+import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.collectRulesetNames;
+import static io.codiga.plugins.jetbrains.services.CodigaConfigFileUtil.findCodigaConfigFile;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.util.WaitFor;
+import io.codiga.api.type.LanguageEnumeration;
+import io.codiga.plugins.jetbrains.annotators.RosieRulesCache;
+import io.codiga.plugins.jetbrains.graphql.CodigaApi;
+import io.codiga.plugins.jetbrains.graphql.RulesetsForClientTestSupport;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Integration test for {@link RosieRulesCacheUpdateHandler}.
+ */
+public class RosieRulesCacheUpdateHandlerTest extends TestBase {
+
+    @Override
+    protected String getTestDataRelativePath() {
+        return TEST_DATA_BASE_PATH + "/rosiecacheupdater";
+    }
+
+    /**
+     * This case, that there is something in the cache before there was any codiga.yml file in the first place,
+     * isn't supposed to happen, but decided to still leave it here.
+     */
+    public void testClearsCacheIfThereWasNeverACodigaConfigFile() {
+        //Don't add codiga.yml, just manually set something in the cache
+        RosieRulesCache rulesCache = RosieRulesCache.getInstance(getProject());
+        rulesCache.updateCacheFrom(RulesetsForClientTestSupport.singleRulesetSingleLanguage());
+        rulesCache.setLastUpdatedTimeStamp(101L);
+
+        assertSize(3, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        validateThatCacheIsEmpty(rulesCache);
+    }
+
+    public void testClearsCacheIfCodigaConfigFileIsDeleted() {
+        myFixture.copyFileToProject("codiga.yml");
+
+        var codigaConfigFile = findCodigaConfigFile(getProject());
+        RosieRulesCache rulesCache = initializeCache(collectRulesetNames(codigaConfigFile));
+
+        assertSize(3, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+
+        //Delete the config file
+        WriteAction.runAndWait(() -> CommandProcessor.getInstance()
+            .executeCommand(getProject(), codigaConfigFile::delete, "Delete", "group.id"));
+        //Waits for the deletion to actually take effect
+        new WaitFor(2000, 2000) {
+            @Override
+            protected boolean condition() {
+                return !codigaConfigFile.getVirtualFile().exists();
+            }
+        };
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        validateThatCacheIsEmpty(rulesCache);
+    }
+
+    public void testClearsCacheIfTheCodigaConfigFileIsModifiedButItIsEmpty() {
+        RosieRulesCache rulesCache = initializeCacheFromCodigaConfigFile();
+
+        assertSize(3, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+
+        replaceContentsOfCodigaConfigFileWith("");
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        validateThatCacheIsEmpty(rulesCache);
+    }
+
+    public void testDoesntUpdateCacheIfTheCodigaConfigFileIsModifiedButNoRulesetsForClientIsReceivedDueToError() {
+        RosieRulesCache rulesCache = initializeCacheFromCodigaConfigFile();
+        long originalModificationStamp = rulesCache.getConfigFileModificationStamp();
+
+        replaceContentsOfCodigaConfigFileWith("rulesets:\n  - erroredRuleset");
+
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertFalse(rulesCache.isEmpty());
+        assertEquals(100L, rulesCache.getLastUpdatedTimeStamp());
+        //Asserting not equals, in case the new modification stamp would not be consistently the same value.
+        assertNotEquals(rulesCache.getConfigFileModificationStamp(), originalModificationStamp);
+    }
+
+    public void testClearsCachedRulesIfTheCodigaConfigFileIsModifiedButEmptyListOfRulesetsForClientIsReceived() {
+        RosieRulesCache rulesCache = initializeCacheFromCodigaConfigFile();
+
+        replaceContentsOfCodigaConfigFileWith("rulesets:\n  - non-existent-ruleset");
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertTrue(rulesCache.isEmpty());
+        assertEquals(-1, rulesCache.getLastUpdatedTimeStamp());
+    }
+
+    public void testUpdatesCacheIfTheCodigaConfigFileIsModifiedAndDoesntUpdateUnchangedTimestamp() {
+        RosieRulesCache rulesCache = initializeCacheFromCodigaConfigFile();
+
+        replaceContentsOfCodigaConfigFileWith("rulesets:\n  - singleRulesetMultipleLanguagesDefaultTimestamp");
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(100, rulesCache.getLastUpdatedTimeStamp());
+    }
+
+    public void testUpdatesCacheIfTheCodigaConfigFileIsModifiedAndUpdatesChangedTimestamp() {
+        RosieRulesCache rulesCache = initializeCacheFromCodigaConfigFile();
+
+        replaceContentsOfCodigaConfigFileWith("rulesets:\n  - singleRulesetMultipleLanguages");
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(102, rulesCache.getLastUpdatedTimeStamp());
+    }
+
+    //Changes on the server
+
+    public void testDoesntUpdateCacheIfSameTimestampIsReceivedFromServer() {
+        myFixture.copyFileToProject("codiga.yml");
+
+        RosieRulesCache rulesCache = RosieRulesCache.getInstance(getProject());
+        rulesCache.updateCacheFrom(RulesetsForClientTestSupport.singleRulesetMultipleLanguages());
+        rulesCache.setLastUpdatedTimeStamp(101L);
+
+        assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(101, rulesCache.getLastUpdatedTimeStamp());
+
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(101, rulesCache.getLastUpdatedTimeStamp());
+    }
+
+    public void testUpdatesCacheIfDifferentLatestTimestampIsReceived() {
+        myFixture.copyFileToProject("codiga.yml");
+
+        RosieRulesCache rulesCache = RosieRulesCache.getInstance(getProject());
+        rulesCache.updateCacheFrom(RulesetsForClientTestSupport.singleRulesetMultipleLanguages());
+        rulesCache.setLastUpdatedTimeStamp(102L);
+
+        assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(102, rulesCache.getLastUpdatedTimeStamp());
+
+        new RosieRulesCacheUpdateHandler(rulesCache, getProject()).handleCacheUpdate();
+
+        assertSize(3, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
+        assertEquals(101, rulesCache.getLastUpdatedTimeStamp());
+    }
+
+    //Helpers
+
+    @NotNull
+    private RosieRulesCache initializeCacheFromCodigaConfigFile() {
+        myFixture.copyFileToProject("codiga.yml");
+
+        var codigaConfigFile = findCodigaConfigFile(getProject());
+        var rulesetNames = collectRulesetNames(codigaConfigFile);
+        return initializeCache(rulesetNames);
+    }
+
+    /**
+     * Initializes the cache with based on the provided test ruleset names.
+     */
+    @NotNull
+    private RosieRulesCache initializeCache(List<String> rulesetNames) {
+        var rulesetsFromCodigaAPI = CodigaApi.getInstance().getRulesetsForClient(rulesetNames).get();
+        var rulesCache = RosieRulesCache.getInstance(getProject());
+
+        rulesCache.updateCacheFrom(rulesetsFromCodigaAPI);
+        rulesCache.setLastUpdatedTimeStamp(100L);
+        rulesCache.setConfigFileModificationStamp(1);
+        return rulesCache;
+    }
+
+    /**
+     * Replace the whole content of the Codiga config file, esentially doing a modification on the file.
+     */
+    private void replaceContentsOfCodigaConfigFileWith(String replacement) {
+        myFixture.configureByFile("codiga.yml");
+
+        WriteAction.runAndWait(() -> CommandProcessor.getInstance()
+            .executeCommand(getProject(),
+                () -> {
+                    Document document = myFixture.getEditor().getDocument();
+                    document.replaceString(0, document.getTextLength(), replacement);
+                    PsiDocumentManager.getInstance(getProject()).commitAllDocuments();
+                },
+                "Modify File Content", "group.id"));
+    }
+
+    protected static void validateThatCacheIsEmpty(RosieRulesCache rulesCache) {
+        assertTrue(rulesCache.isEmpty());
+        assertEquals(-1, rulesCache.getLastUpdatedTimeStamp());
+    }
+}


### PR DESCRIPTION
### Changes
- Added integration tests for the cache updater, for both flows:
  - `codiga.yml` is modified
  - rules changed on the server
- `RosieRulesCache`
  - Adjusted the stamp default values.
  - Resetting the `lastUpdatedTimeStamp` during cache clear, regardless the cache was clear or not.
- `RosieRulesCacheUpdater`
  - Extracted the cache update logic to a new class called `RosieRulesCacheUpdateHandler`, so that it can be tested separately from the background task.
  - The background task is now turned off in case of integration tests, so that it doesn't interfere with test logic.
- `RosieRulesCacheUpdateHandler`
  - Added extra validation on `VirtualFile` level, so that if `codiga.yml` does not exist (regardless if the `YAMLFile` instance is still present), the cache gets cleared.
  - If there is an empty list of rulesets returned from the Codiga API due to misconfiguration of `codiga.yml`, the cache gets cleared.