### PR TITLE
Don't trigger inline completion for comments containing todo keywords

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/utils/LanguageUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/LanguageUtils.java
@@ -143,6 +143,9 @@ public final class LanguageUtils {
         }
     }
 
+    /**
+     * Keywords here are specified as lowercase values, and compared against the lowercase version of comment lines.
+     */
     private static final Set<String> KEYWORDS_TO_FILTER_OUT = Set.of("todo", "fixme");
 
     public static @NotNull String removeLineFromCommentsSymbols(@NotNull String line) {

--- a/src/main/java/io/codiga/plugins/jetbrains/utils/LanguageUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/LanguageUtils.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public final class LanguageUtils {
 
@@ -142,12 +143,21 @@ public final class LanguageUtils {
         }
     }
 
+    private static final Set<String> KEYWORDS_TO_FILTER_OUT = Set.of("todo", "fixme");
+
     public static @NotNull String removeLineFromCommentsSymbols(@NotNull String line) {
         return line.replaceAll("#", "").replaceAll("//", "");
     }
 
     public static long numberOfWordsInComment(@NotNull String line) {
-        return Arrays.asList(removeLineFromCommentsSymbols(line).split(" ")).stream().filter(s -> s.length() > 0).count();
+        return Arrays.stream(removeLineFromCommentsSymbols(line).split(" ")).filter(s -> !s.isEmpty()).count();
+    }
+
+    /**
+     * Returns whether the argument line contains lower-case any of the {@link #KEYWORDS_TO_FILTER_OUT}.
+     */
+    public static boolean containsTodoKeyword(@NotNull String line) {
+        return KEYWORDS_TO_FILTER_OUT.stream().anyMatch(keyword -> line.toLowerCase().contains(keyword));
     }
 
     /**

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
@@ -117,6 +117,13 @@ public class InlineCompletionTest extends TestBase {
         assertNull(SnippetPreview.getInstance(myFixture.getEditor()));
     }
 
+    public void testNoSnippetPreviewWhenCompletionKeywordsContainTodoKeyword() {
+        myFixture.configureByFile("github_ci_config.yml");
+        myFixture.type("sometodo");
+
+        assertNull(SnippetPreview.getInstance(myFixture.getEditor()));
+    }
+
     //Settings based cases
 
     public void testNoSnippetPreviewWhenCodigaIsDisabled() {

--- a/src/test/java/io/codiga/plugins/jetbrains/utils/LanguageUtilsTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/utils/LanguageUtilsTest.java
@@ -1,0 +1,73 @@
+package io.codiga.plugins.jetbrains.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link LanguageUtils}.
+ */
+public class LanguageUtilsTest {
+
+    //numberOfWordsInComment()
+
+    @Test
+    public void shouldReturnZeroForEmptyLine() {
+        long numberOfWords = LanguageUtils.numberOfWordsInComment("");
+
+        assertEquals(0, numberOfWords);
+    }
+
+    @Test
+    public void shouldReturnZeroForEmptyCommentLine() {
+        long numberOfWords = LanguageUtils.numberOfWordsInComment("//");
+
+        assertEquals(0, numberOfWords);
+    }
+
+    @Test
+    public void shouldReturnNumberOfNonEmptyComments() {
+        long numberOfWords = LanguageUtils.numberOfWordsInComment("//this   is  a list of      words");
+
+        assertEquals(6, numberOfWords);
+    }
+
+    //containsTodoKeyword()
+
+    @Test
+    public void shouldReturnTrueWhenContainsTodoKeywordAtLineStartAsStandaloneWord() {
+        boolean containsTodoKeyword = LanguageUtils.containsTodoKeyword("//todo task");
+
+        assertTrue(containsTodoKeyword);
+    }
+
+    @Test
+    public void shouldReturnTrueWhenContainsTodoKeywordAtLineStartAsPartOfWord() {
+        boolean containsTodoKeyword = LanguageUtils.containsTodoKeyword("//todo:task");
+
+        assertTrue(containsTodoKeyword);
+    }
+
+    @Test
+    public void shouldReturnTrueWhenContainsFixmeKeyword() {
+        boolean containsTodoKeyword = LanguageUtils.containsTodoKeyword("//some keyword fixmeplease");
+
+        assertTrue(containsTodoKeyword);
+    }
+
+    @Test
+    public void shouldReturnTrueWhenContainsUppercaseTodoKeyword() {
+        boolean containsTodoKeyword = LanguageUtils.containsTodoKeyword("//some keyword FIXME:please");
+
+        assertTrue(containsTodoKeyword);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenDoesntContainTodoKeyword() {
+        boolean containsTodoKeyword = LanguageUtils.containsTodoKeyword("//some keyword");
+
+        assertFalse(containsTodoKeyword);
+    }
+}


### PR DESCRIPTION
### Changes
- `LanguageUtils`
  - Added the `containsTodoKeyword()` method to check whether a line contains `todo` or `fixme` kwywords.
  - Simplified the `numberOfWordsInComment()` method.
- `InlineDocumentListener`
  - Snippet preview is no longer triggered when the comment line contains a `todo` or `fixme` keyword.
  - Extracted the line retrieval and completion eligibility checking into a separate method.
  - Removed a null check, since `Document#getText()`, by its method contract, returns non-null value.
- Added unit and integration tests.