### PR TITLE
Housekeeping and finetuning

### DIFF
--- a/.run/Run Build Plugin.run.xml
+++ b/.run/Run Build Plugin.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Build Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="buildPlugin" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run IDE with Plugin.run.xml
+++ b/.run/Run IDE with Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run Plugin Tests.run.xml
+++ b/.run/Run Plugin Tests.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Run Verifications.run.xml
+++ b/.run/Run Verifications.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Verifications" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runPluginVerifier" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import com.intellij.ui.DocumentAdapter;
 import com.intellij.util.Alarm;
 import com.intellij.util.ui.AsyncProcessIcon;
 import io.codiga.api.GetRecipesForClientSemanticQuery;
@@ -21,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.util.List;
 import java.util.Optional;
@@ -83,8 +83,9 @@ public class SnippetToolWindow {
          * in order to not hammer the backend with too many requests. We only make a
          * request if no key has not been typed within 500 ms.
          */
-        searchTerm.getDocument().addDocumentListener(new DocumentListener() {
-            private void updateResult() {
+        searchTerm.getDocument().addDocumentListener(new DocumentAdapter() {
+            @Override
+            protected void textChanged(@NotNull DocumentEvent e) {
 
                 FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
 
@@ -114,17 +115,7 @@ public class SnippetToolWindow {
             }
 
             @Override
-            public void insertUpdate(DocumentEvent e) {
-                updateResult();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                updateResult();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
+            public void changedUpdate(@NotNull DocumentEvent e) {
                 // empty, nothing needed here
             }
         });
@@ -176,20 +167,6 @@ public class SnippetToolWindow {
                 .map(FileEditorManager::getSelectedEditor)
                 .map(FileEditor::getFile)
                 .ifPresent(virtualFile -> updateEditor(project, virtualFile, Optional.empty(), true));
-
-//            FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
-//            if (fileEditorManager == null) {
-//                return;
-//            }
-//            FileEditor fileEditor = fileEditorManager.getSelectedEditor();
-//            if (fileEditor == null) {
-//                return;
-//            }
-//            VirtualFile virtualFile = fileEditor.getFile();
-//            if (virtualFile == null) {
-//                return;
-//            }
-//            updateEditor(project, virtualFile, Optional.empty(), true);
         });
 
 

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
@@ -171,19 +171,25 @@ public class SnippetToolWindow {
                 LOGGER.info("Project already disposed");
                 return;
             }
-            FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
-            if (fileEditorManager == null) {
-                return;
-            }
-            FileEditor fileEditor = fileEditorManager.getSelectedEditor();
-            if (fileEditor == null) {
-                return;
-            }
-            VirtualFile virtualFile = fileEditor.getFile();
-            if (virtualFile == null) {
-                return;
-            }
-            updateEditor(project, virtualFile, Optional.empty(), true);
+
+            Optional.ofNullable(FileEditorManager.getInstance(project))
+                .map(FileEditorManager::getSelectedEditor)
+                .map(FileEditor::getFile)
+                .ifPresent(virtualFile -> updateEditor(project, virtualFile, Optional.empty(), true));
+
+//            FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
+//            if (fileEditorManager == null) {
+//                return;
+//            }
+//            FileEditor fileEditor = fileEditorManager.getSelectedEditor();
+//            if (fileEditor == null) {
+//                return;
+//            }
+//            VirtualFile virtualFile = fileEditor.getFile();
+//            if (virtualFile == null) {
+//                return;
+//            }
+//            updateEditor(project, virtualFile, Optional.empty(), true);
         });
 
 

--- a/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/snippet_search/SnippetToolWindow.java
@@ -18,6 +18,9 @@ import io.codiga.plugins.jetbrains.SnippetVisibility;
 import io.codiga.plugins.jetbrains.dependencies.DependencyManagement;
 import io.codiga.plugins.jetbrains.graphql.CodigaApi;
 import io.codiga.plugins.jetbrains.settings.application.AppSettingsState;
+import io.codiga.plugins.jetbrains.topics.ApiKeyChangeNotifier;
+import io.codiga.plugins.jetbrains.topics.SnippetToolWindowFileChangeNotifier;
+import io.codiga.plugins.jetbrains.topics.VisibilityKeyChangeNotifier;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -142,32 +145,33 @@ public class SnippetToolWindow {
          * case, we update the user and search preferences.
          */
         ApplicationManager.getApplication().getMessageBus().connect().subscribe(CODIGA_API_KEY_CHANGE_TOPIC,
-            context -> {
+            (ApiKeyChangeNotifier) context -> {
                 updateUser();
                 updateSearchPreferences();
             });
 
         ApplicationManager.getApplication().getMessageBus().connect().subscribe(CODIGA_VISIBILITY_CHANGE_TOPIC,
-            context -> {
+            (VisibilityKeyChangeNotifier) context -> {
                 updateUser();
                 initVisibilityFromSettings();
                 updateSearchPreferences();
             });
 
-        ApplicationManager.getApplication().getMessageBus().connect().subscribe(CODIGA_NEW_FILE_SELECTED_TOPIC, context -> {
-            updateUser();
+        ApplicationManager.getApplication().getMessageBus().connect().subscribe(CODIGA_NEW_FILE_SELECTED_TOPIC,
+            (SnippetToolWindowFileChangeNotifier) context -> {
+                updateUser();
 
-            // Check if project still active
-            if (project.isDisposed()) {
-                LOGGER.info("Project already disposed");
-                return;
-            }
+                // Check if project still active
+                if (project.isDisposed()) {
+                    LOGGER.info("Project already disposed");
+                    return;
+                }
 
-            Optional.ofNullable(FileEditorManager.getInstance(project))
-                .map(FileEditorManager::getSelectedEditor)
-                .map(FileEditor::getFile)
-                .ifPresent(virtualFile -> updateEditor(project, virtualFile, Optional.empty(), true));
-        });
+                Optional.ofNullable(FileEditorManager.getInstance(project))
+                    .map(FileEditorManager::getSelectedEditor)
+                    .map(FileEditor::getFile)
+                    .ifPresent(virtualFile -> updateEditor(project, virtualFile, Optional.empty(), true));
+            });
 
 
         /**

--- a/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumber.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerRndNumber.java
@@ -2,10 +2,6 @@ package io.codiga.plugins.jetbrains.assistant.transformers;
 
 import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Locale;
 import java.util.Random;
 
 public class VariableTransformerRndNumber implements VariableTransformer {

--- a/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondsUnix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableTransformerSecondsUnix.java
@@ -2,11 +2,7 @@ package io.codiga.plugins.jetbrains.assistant.transformers;
 
 import io.codiga.plugins.jetbrains.model.CodingAssistantContext;
 
-import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Locale;
 
 public class VariableTransformerSecondsUnix implements VariableTransformer {
   /**

--- a/src/main/java/io/codiga/plugins/jetbrains/dependencies/AbstractDependency.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/dependencies/AbstractDependency.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/codiga/plugins/jetbrains/dependencies/DependencyManagement.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/dependencies/DependencyManagement.java
@@ -3,10 +3,8 @@ package io.codiga.plugins.jetbrains.dependencies;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.codiga.api.type.LanguageEnumeration;
-import io.codiga.plugins.jetbrains.cache.ShortcutCache;
 import io.codiga.plugins.jetbrains.model.Dependency;
 import com.google.common.collect.ImmutableList;
-import com.intellij.psi.PsiFile;
 import io.codiga.plugins.jetbrains.graphql.LanguageUtils;
 
 import java.util.List;

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRequest.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRequest.java
@@ -1,10 +1,13 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.AllArgsConstructor;
+
 import java.util.List;
 
 /**
  * Rosie request object sent to the Codiga API.
  */
+@AllArgsConstructor
 public class RosieRequest {
     public String filename;
     /**
@@ -21,14 +24,4 @@ public class RosieRequest {
     public String codeBase64;
     public List<RosieRule> rules;
     public boolean logOutput;
-
-
-    public RosieRequest(String filename, String language, String fileEncoding, String codeBase64, List<RosieRule> rosieRules, boolean logOutput) {
-        this.filename = filename;
-        this.language = language;
-        this.fileEncoding = fileEncoding;
-        this.codeBase64 = codeBase64;
-        this.rules = rosieRules;
-        this.logOutput = logOutput;
-    }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRuleResponse.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRuleResponse.java
@@ -1,38 +1,18 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
 import java.util.List;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class RosieRuleResponse {
     public String identifier;
     public List<RosieViolation> violations;
     public List<String> errors;
     public String executionError;
     public String output;
-
-    public RosieRuleResponse() {
-        this.identifier = null;
-        this.violations = null;
-        this.errors = null;
-        this.executionError = null;
-        this.output = null;
-    }
-
-    public RosieRuleResponse(String identifier, List<RosieViolation> violations, List<String> errors, String executionError, String output) {
-        this.identifier = identifier;
-        this.violations = violations;
-        this.errors = errors;
-        this.executionError = executionError;
-        this.output = output;
-    }
-
-    @Override
-    public String toString() {
-        return "RuleResponse{" +
-            "identifier='" + identifier + '\'' +
-            ", violations=" + violations +
-            ", errors=" + errors +
-            ", executionError='" + executionError + '\'' +
-            ", output='" + output + '\'' +
-            '}';
-    }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieViolationFix.java
@@ -1,5 +1,6 @@
 package io.codiga.plugins.jetbrains.model.rosie;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
@@ -9,13 +10,9 @@ import java.util.List;
  * <p>
  * {@link io.codiga.plugins.jetbrains.annotators.RosieAnnotationFix} works based on the information stored here.
  */
+@AllArgsConstructor
 @EqualsAndHashCode
 public final class RosieViolationFix {
     public String description;
     public List<RosieViolationFixEdit> edits;
-
-    public RosieViolationFix(String description, List<RosieViolationFixEdit> edits) {
-        this.description = description;
-        this.edits = edits;
-    }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/ApiKeyChangeNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/ApiKeyChangeNotifier.java
@@ -8,11 +8,7 @@ import com.intellij.util.messages.Topic;
  * We subscribe to this topic in the preferences when the API key change in order to refresh the list
  * of projects.
  */
-public interface ApiKeyChangeNotifier {
+public interface ApiKeyChangeNotifier extends ChangeNotifier{
     Topic<ApiKeyChangeNotifier> CODIGA_API_KEY_CHANGE_TOPIC =
         Topic.create("Codiga API key change", ApiKeyChangeNotifier.class);
-
-
-    void beforeAction(Object context);
-    void afterAction(Object context);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/ChangeNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/ChangeNotifier.java
@@ -1,0 +1,15 @@
+package io.codiga.plugins.jetbrains.topics;
+
+/**
+ * Common interface for classes that provide {@link com.intellij.util.messages.Topic}s for subscribing to various changes.
+ */
+public interface ChangeNotifier {
+
+    /**
+     * No-op by default.
+     */
+    default void beforeAction(Object context) {
+    }
+
+    void afterAction(Object context);
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/CodigaEnabledStatusNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/CodigaEnabledStatusNotifier.java
@@ -8,12 +8,8 @@ import com.intellij.util.messages.Topic;
  * We subscribe to this topic in the preferences when the API key change in order to refresh the list
  * of projects.
  */
-public interface CodigaEnabledStatusNotifier {
+public interface CodigaEnabledStatusNotifier extends ChangeNotifier {
 
     Topic<CodigaEnabledStatusNotifier> CODIGA_ENABLED_CHANGE_TOPIC =
         Topic.create("Codiga inline completion change", CodigaEnabledStatusNotifier.class);
-
-    void beforeAction(Object context);
-
-    void afterAction(Object context);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/SnippetToolWindowFileChangeNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/SnippetToolWindowFileChangeNotifier.java
@@ -6,12 +6,8 @@ import com.intellij.util.messages.Topic;
  * This topic represent when there was a file change on the file system.
  * In that case, we refresh the snippets shown in the snippet search.
  */
-public interface SnippetToolWindowFileChangeNotifier {
+public interface SnippetToolWindowFileChangeNotifier extends ChangeNotifier {
 
     Topic<SnippetToolWindowFileChangeNotifier> CODIGA_NEW_FILE_SELECTED_TOPIC =
         Topic.create("New file selected", SnippetToolWindowFileChangeNotifier.class);
-
-    void beforeAction(Object context);
-
-    void afterAction(Object context);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/topics/VisibilityKeyChangeNotifier.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/topics/VisibilityKeyChangeNotifier.java
@@ -8,12 +8,8 @@ import com.intellij.util.messages.Topic;
  * We subscribe to this topic in the preferences when the API key change in order to refresh the list
  * of projects.
  */
-public interface VisibilityKeyChangeNotifier {
+public interface VisibilityKeyChangeNotifier extends ChangeNotifier {
 
     Topic<VisibilityKeyChangeNotifier> CODIGA_VISIBILITY_CHANGE_TOPIC =
         Topic.create("Codiga snippets visibility change", VisibilityKeyChangeNotifier.class);
-
-    void beforeAction(Object context);
-
-    void afterAction(Object context);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
@@ -47,18 +47,7 @@ public class StatusBar implements StatusBarWidgetFactory {
         if (statusBar != null) {
             ApplicationManager.getApplication()
                 .getMessageBus().connect()
-                .subscribe(CodigaEnabledStatusNotifier.CODIGA_ENABLED_CHANGE_TOPIC, new CodigaEnabledStatusNotifier() {
-
-                    @Override
-                    public void beforeAction(Object context) {
-                        // no need any before action
-                    }
-
-                    @Override
-                    public void afterAction(Object context) {
-                        statusBar.updateWidget(getId());
-                    }
-                });
+                .subscribe(CodigaEnabledStatusNotifier.CODIGA_ENABLED_CHANGE_TOPIC, context -> statusBar.updateWidget(getId()));
         }
         return new CodigaStatusWidget();
     }

--- a/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
@@ -47,7 +47,8 @@ public class StatusBar implements StatusBarWidgetFactory {
         if (statusBar != null) {
             ApplicationManager.getApplication()
                 .getMessageBus().connect()
-                .subscribe(CodigaEnabledStatusNotifier.CODIGA_ENABLED_CHANGE_TOPIC, context -> statusBar.updateWidget(getId()));
+                .subscribe(CodigaEnabledStatusNotifier.CODIGA_ENABLED_CHANGE_TOPIC,
+                    (CodigaEnabledStatusNotifier) context -> statusBar.updateWidget(getId()));
         }
         return new CodigaStatusWidget();
     }

--- a/src/main/java/io/codiga/plugins/jetbrains/utils/CodeImportUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/CodeImportUtils.java
@@ -4,10 +4,8 @@ import io.codiga.api.type.LanguageEnumeration;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static io.codiga.plugins.jetbrains.Constants.LINE_SEPARATOR;
-import static io.codiga.plugins.jetbrains.Constants.PYTHON_IMPORT_KEYWORD;
 
 /**
  * All methods to handle imports in code. This is specifally used in the coding


### PR DESCRIPTION
### Changes
- Removed unused imports.
- Simplified a few model classes with Lombok.
- Added IntelliJ Run Configurations specific to plugin development.
  - This way they persist in the Run Configuration dropdown.
- Introduced a parent interface, `ChangeNotifier`, for topic listener classes. This way
  - the implementation of those classes is simplfied,
  - since `beforeAction()` is not called anywhere now, the notifier types can be handled as functional interfaces and lambda expressions at their places of usage.
- `SnippetToolWindow`
  - Replaced some null checks with an `Optional` chain.
  - Replaced `DocumentListener` with `DocumentAdapter` to have a simpler code there.