### PR TITLE
Settings UI enhancements and status bar bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@
 - Added JSON/YAML schema provider for the `codiga.yml` config file, so that code completion and automatic validation in that file is performed automatically.
 
 ### Changed
+- Improved the plugin's settings UI.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fixed a UI issue on the plugin's settings page that the checkboxes did not reflect Codiga's disabled state.
+- Fixed the issue that the status bar icon's tooltip text did not update upon enabling/disabling Codiga.
 
 ### Security
 

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
@@ -205,12 +205,14 @@ public class AppSettingsComponent {
     public void setUseInlineComplextion(Boolean b) {
         this.useInlineCompletion = b;
         this.useInlineCompletionCheckbox.setSelected(b);
+        this.useInlineCompletionCheckbox.setEnabled(codigaEnabled);
     }
 
     public void setUseEnabledCheckbox(Boolean b) {
         if (this.useCompletionCheckbox != null) {
             this.useCompletion = b;
             this.useCompletionCheckbox.setSelected(b);
+            this.useCompletionCheckbox.setEnabled(codigaEnabled);
         }
     }
 

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
@@ -58,6 +58,12 @@ public class AppSettingsComponent {
         JButton buttonTestConnection = new JButton(SETTINGS_TEST_API_BUTTON_TEXT);
         JButton buttonGetApiKeys = new JButton(SETTINGS_GET_API_TOKEN_BUTTON_TEXT);
 
+        //The button group is responsible for making sure that only one
+        // radio button in that group can be selected at a time
+        var snippetVisibilityGroup = new ButtonGroup();
+        snippetVisibilityGroup.add(snippetsVisibilityAll);
+        snippetVisibilityGroup.add(snippetsVisibilityPublic);
+        snippetVisibilityGroup.add(snippetsVisibilityPrivate);
 
         useCompletionCheckbox = new JCheckBox(SETTINGS_ENABLED_COMPLETION);
 
@@ -71,16 +77,13 @@ public class AppSettingsComponent {
                 this.snippetsPublicOnly = false;
                 this.snippetsPrivateOnly = false;
             }
-            setSnippetsVisiliblity(this.snippetsPrivateOnly, this.snippetsPublicOnly, this.snippetsFavoriteOnly);
         });
-
 
         snippetsVisibilityPublic.addActionListener(event -> {
             if (snippetsVisibilityPublic.isSelected()) {
                 this.snippetsPublicOnly = true;
                 this.snippetsPrivateOnly = false;
             }
-            setSnippetsVisiliblity(this.snippetsPrivateOnly, this.snippetsPublicOnly, this.snippetsFavoriteOnly);
         });
 
         snippetsVisibilityPrivate.addActionListener(event -> {
@@ -88,18 +91,14 @@ public class AppSettingsComponent {
                 this.snippetsPublicOnly = false;
                 this.snippetsPrivateOnly = true;
             }
-            setSnippetsVisiliblity(this.snippetsPrivateOnly, this.snippetsPublicOnly, this.snippetsFavoriteOnly);
         });
 
 
-        snippetsVisibilityFavoriteOnly.addActionListener(event -> {
-            this.snippetsFavoriteOnly = snippetsVisibilityFavoriteOnly.isSelected();
-            setSnippetsVisiliblity(this.snippetsPrivateOnly, this.snippetsPublicOnly, this.snippetsFavoriteOnly);
-        });
+        snippetsVisibilityFavoriteOnly.addActionListener(event ->
+            this.snippetsFavoriteOnly = snippetsVisibilityFavoriteOnly.isSelected());
 
-        useInlineCompletionCheckbox.addActionListener(event -> {
-            this.useInlineCompletion = useInlineCompletionCheckbox.isSelected();
-        });
+        useInlineCompletionCheckbox.addActionListener(event ->
+            this.useInlineCompletion = useInlineCompletionCheckbox.isSelected());
 
         codigaEnabledCheckbox.addActionListener(event -> {
             this.codigaEnabled = codigaEnabledCheckbox.isSelected();
@@ -215,37 +214,30 @@ public class AppSettingsComponent {
         }
     }
 
-    public void setSnippetsVisiliblity(boolean privateOnly, boolean publicOnly, boolean favoriteOnly) {
+    public void setSnippetsVisibility(boolean privateOnly, boolean publicOnly, boolean favoriteOnly) {
         LOGGER.debug("private: " + privateOnly);
         LOGGER.debug("public: " + publicOnly);
         LOGGER.debug("favorite: " + favoriteOnly);
         this.snippetsPublicOnly = publicOnly;
         this.snippetsFavoriteOnly = favoriteOnly;
         this.snippetsPrivateOnly = privateOnly;
-        if (this.snippetsVisibilityAll == null || this.snippetsVisibilityPrivate == null || this.snippetsVisibilityPublic == null || this.snippetsVisibilityFavoriteOnly == null) {
+        if (this.snippetsVisibilityAll == null
+            || this.snippetsVisibilityPrivate == null
+            || this.snippetsVisibilityPublic == null
+            || this.snippetsVisibilityFavoriteOnly == null) {
             return;
-
         }
 
         if (!privateOnly && !publicOnly) {
             this.snippetsVisibilityAll.setSelected(true);
-            this.snippetsVisibilityPublic.setSelected(false);
-            this.snippetsVisibilityPrivate.setSelected(false);
         }
         if (!privateOnly && publicOnly) {
-            this.snippetsVisibilityAll.setSelected(false);
             this.snippetsVisibilityPublic.setSelected(true);
-            this.snippetsVisibilityPrivate.setSelected(false);
         }
         if (privateOnly && !publicOnly) {
-            this.snippetsVisibilityAll.setSelected(false);
-            this.snippetsVisibilityPublic.setSelected(false);
             this.snippetsVisibilityPrivate.setSelected(true);
         }
 
-
         this.snippetsVisibilityFavoriteOnly.setSelected(favoriteOnly);
-
     }
 }
-

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
@@ -2,10 +2,11 @@ package io.codiga.plugins.jetbrains.settings.application;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.TitledSeparator;
 import com.intellij.ui.components.JBCheckBox;
-import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBRadioButton;
 import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.UI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import io.codiga.plugins.jetbrains.graphql.CodigaApi;
 import io.codiga.plugins.jetbrains.ui.DialogApiStatus;
@@ -128,20 +129,26 @@ public class AppSettingsComponent {
         buttonsPanel.add(buttonGetApiKeys);
         buttonsPanel.add(buttonTestConnection);
         p.addToRight(buttonsPanel);
-        myMainPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(new JBLabel(SETTINGS_API_TOKEN_LABEL), apiToken, 1, false)
-            .addLabeledComponent(new JBLabel("            "), new JBLabel(" Add your Codiga API keys to use your recipes in your IDE."), 1, false)
-            .addComponent(p, 0)
-            .addLabeledComponent(this.codigaEnabledCheckbox, new JBLabel(SETTINGS_ENABLED_CODIGA))
-            .addLabeledComponent(this.useCompletationCheckbox, new JBLabel(SETTINGS_ENABLED_COMPLETION))
-            .addLabeledComponent(useInlineCompletionCheckbox, new JBLabel(SETTINGS_ENABLED_INLINE_COMPLETION))
-            .addSeparator(1)
 
-            .addComponent(new JLabel(SETTINGS_SNIPPETS_VISIBILITY_PARAMETERS), 1)
-            .addLabeledComponent(snippetsVisibilityAll, new JBLabel(SETTINGS_SNIPPETS_VISIBILITY_ALL_SNIPPETS))
-            .addLabeledComponent(snippetsVisibilityPublic, new JBLabel(SETTINGS_SNIPPETS_VISIBILITY_PUBLIC_SNIPPETS_ONLY))
-            .addLabeledComponent(snippetsVisibilityPrivate, new JBLabel(SETTINGS_SNIPPETS_VISIBILITY_PRIVATE_ONLY))
-            .addLabeledComponent(snippetsVisibilityFavoriteOnly, new JBLabel(SETTINGS_SNIPPETS_VISIBILITY_FAVORITE_ONLY))
+        JPanel apiTokenPanel = UI.PanelFactory.panel(apiToken).withComment(SETTINGS_API_TOKEN_COMMENT).createPanel();
+        myMainPanel = FormBuilder.createFormBuilder()
+            .addComponent(new TitledSeparator(SETTINGS_CODIGA_ACCOUNT_SECTION_TITLE))
+            .addVerticalGap(2)
+            .addLabeledComponent(SETTINGS_API_TOKEN_LABEL, apiTokenPanel, 1, true)
+            .addComponent(p, 0)
+
+            .addComponent(new TitledSeparator(SETTINGS_CODE_AND_INLINE_COMPLETION_SECTION_TITLE))
+            .addComponent(this.codigaEnabledCheckbox)
+            .addComponent(this.useCompletionCheckbox)
+            .addComponent(useInlineCompletionCheckbox)
+            .addVerticalGap(3)
+
+            .addComponent(new TitledSeparator(SETTINGS_SNIPPETS_VISIBILITY_PARAMETERS))
+            .addComponent(snippetsVisibilityAll)
+            .addComponent(snippetsVisibilityPublic)
+            .addComponent(snippetsVisibilityPrivate)
+            .addVerticalGap(2)
+            .addComponent(snippetsVisibilityFavoriteOnly)
             .addVerticalGap(5)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
@@ -158,10 +165,7 @@ public class AppSettingsComponent {
 
     @NotNull
     public String getApiToken() {
-        if (apiToken.getPassword() == null){
-            return "";
-        }
-        if (apiToken.getPassword().length == 0){
+        if (apiToken.getPassword() == null || apiToken.getPassword().length == 0) {
             return "";
         }
         return new String(apiToken.getPassword());
@@ -202,7 +206,7 @@ public class AppSettingsComponent {
         }
     }
 
-    public void setUseInlineComplextion(Boolean b) {
+    public void setUseInlineCompletion(Boolean b) {
         this.useInlineCompletion = b;
         this.useInlineCompletionCheckbox.setSelected(b);
         this.useInlineCompletionCheckbox.setEnabled(codigaEnabled);

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsComponent.java
@@ -28,13 +28,13 @@ public class AppSettingsComponent {
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private final JPanel myMainPanel;
     private final JPasswordField apiToken = new JPasswordField(40);
-    private final JCheckBox useCompletationCheckbox;
-    private JBRadioButton snippetsVisibilityAll = new JBRadioButton();
-    private JBRadioButton snippetsVisibilityPublic = new JBRadioButton();
-    private JBRadioButton snippetsVisibilityPrivate = new JBRadioButton();
-    private JBCheckBox snippetsVisibilityFavoriteOnly = new JBCheckBox();
-    private JBCheckBox useInlineCompletionCheckbox = new JBCheckBox();
-    private JBCheckBox codigaEnabledCheckbox = new JBCheckBox();
+    private final JCheckBox useCompletionCheckbox;
+    private JBRadioButton snippetsVisibilityAll = new JBRadioButton(SETTINGS_SNIPPETS_VISIBILITY_ALL_SNIPPETS);
+    private JBRadioButton snippetsVisibilityPublic = new JBRadioButton(SETTINGS_SNIPPETS_VISIBILITY_PUBLIC_SNIPPETS_ONLY);
+    private JBRadioButton snippetsVisibilityPrivate = new JBRadioButton(SETTINGS_SNIPPETS_VISIBILITY_PRIVATE_ONLY);
+    private JBCheckBox snippetsVisibilityFavoriteOnly = new JBCheckBox(SETTINGS_SNIPPETS_VISIBILITY_FAVORITE_ONLY);
+    private JBCheckBox useInlineCompletionCheckbox = new JBCheckBox(SETTINGS_ENABLED_INLINE_COMPLETION);
+    private JBCheckBox codigaEnabledCheckbox = new JBCheckBox(SETTINGS_ENABLED_CODIGA);
     private boolean useCompletion;
     private boolean useInlineCompletion;
     private boolean snippetsPublicOnly;
@@ -59,11 +59,11 @@ public class AppSettingsComponent {
         JButton buttonGetApiKeys = new JButton(SETTINGS_GET_API_TOKEN_BUTTON_TEXT);
 
 
-        useCompletationCheckbox = new JCheckBox();
+        useCompletionCheckbox = new JCheckBox(SETTINGS_ENABLED_COMPLETION);
 
-        useCompletationCheckbox.addActionListener(event -> {
-            LOGGER.debug("setting isDisabled to" + useCompletationCheckbox.isSelected());
-            useCompletion = useCompletationCheckbox.isSelected();
+        useCompletionCheckbox.addActionListener(event -> {
+            LOGGER.debug("setting isDisabled to" + useCompletionCheckbox.isSelected());
+            useCompletion = useCompletionCheckbox.isSelected();
         });
 
         snippetsVisibilityAll.addActionListener(event -> {
@@ -105,8 +105,7 @@ public class AppSettingsComponent {
             this.codigaEnabled = codigaEnabledCheckbox.isSelected();
 
             this.useInlineCompletionCheckbox.setEnabled(this.codigaEnabled);
-            this.useCompletationCheckbox.setEnabled(this.codigaEnabled);
-
+            this.useCompletionCheckbox.setEnabled(this.codigaEnabled);
         });
 
 
@@ -210,9 +209,9 @@ public class AppSettingsComponent {
     }
 
     public void setUseEnabledCheckbox(Boolean b) {
-        if (this.useCompletationCheckbox != null) {
+        if (this.useCompletionCheckbox != null) {
             this.useCompletion = b;
-            this.useCompletationCheckbox.setSelected(b);
+            this.useCompletionCheckbox.setSelected(b);
         }
     }
 

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsConfigurable.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsConfigurable.java
@@ -1,7 +1,6 @@
 package io.codiga.plugins.jetbrains.settings.application;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.Configurable;
 import io.codiga.plugins.jetbrains.topics.ApiKeyChangeNotifier;
 import io.codiga.plugins.jetbrains.topics.CodigaEnabledStatusNotifier;
@@ -11,13 +10,11 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.topics.ApiKeyChangeNotifier.CODIGA_API_KEY_CHANGE_TOPIC;
 import static io.codiga.plugins.jetbrains.topics.CodigaEnabledStatusNotifier.CODIGA_ENABLED_CHANGE_TOPIC;
 import static io.codiga.plugins.jetbrains.topics.VisibilityKeyChangeNotifier.CODIGA_VISIBILITY_CHANGE_TOPIC;
 
 public class AppSettingsConfigurable implements Configurable {
-    private static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     final ApiKeyChangeNotifier apiKeyChangeNotifier =
         ApplicationManager.getApplication().getMessageBus().syncPublisher(CODIGA_API_KEY_CHANGE_TOPIC);
     final VisibilityKeyChangeNotifier visibilityChangeNotifier =

--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsConfigurable.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsConfigurable.java
@@ -82,10 +82,12 @@ public class AppSettingsConfigurable implements Configurable {
         if (settings.getApiToken() != null) {
             mySettingsComponent.setApiToken(settings.getApiToken());
         }
-        mySettingsComponent.setUseEnabledCheckbox(settings.getUseCompletion());
-        mySettingsComponent.setSnippetsVisiliblity(settings.getPrivateSnippetsOnly(), settings.getPublicSnippetsOnly(), settings.getFavoriteSnippetsOnly());
-        mySettingsComponent.setUseInlineComplextion(settings.getUseInlineCompletion());
+        //Make sure this is set before the rest of the code completion checkboxes, because enabling those ones
+        // depends on this one.
         mySettingsComponent.setCodigaEnabled(settings.getCodigaEnabled());
+        mySettingsComponent.setUseEnabledCheckbox(settings.getUseCompletion());
+        mySettingsComponent.setSnippetsVisibility(settings.getPrivateSnippetsOnly(), settings.getPublicSnippetsOnly(), settings.getFavoriteSnippetsOnly());
+        mySettingsComponent.setUseInlineCompletion(settings.getUseInlineCompletion());
     }
 
     @Override

--- a/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/ui/StatusBar.java
@@ -89,7 +89,7 @@ public class StatusBar implements StatusBarWidgetFactory {
 
         @Override
         public @Nullable String getTooltipText() {
-            if (settings.getUseInlineCompletion()) {
+            if (settings.getCodigaEnabled()) {
                 return "Codiga completion is enabled";
             } else {
                 return "Codiga completion is disabled";

--- a/src/main/java/io/codiga/plugins/jetbrains/ui/UIConstants.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/ui/UIConstants.java
@@ -1,28 +1,40 @@
 package io.codiga.plugins.jetbrains.ui;
 
-public class UIConstants {
+public final class UIConstants {
 
-    public final static String SETTINGS_TEST_API_BUTTON_TEXT = "Test API connection";
-    public final static String SETTINGS_GET_API_TOKEN_BUTTON_TEXT = "Get API token";
-    public final static String SETTINGS_API_TOKEN_LABEL = "API Token:";
-    public final static String SETTINGS_SNIPPETS_VISIBILITY_PARAMETERS = "Default Snippets Search when logged in";
+    //API Token
 
-    public final static String SETTINGS_ENABLED_CODIGA = "Enable Codiga";
-    public final static String SETTINGS_ENABLED_INLINE_COMPLETION = "Enable Coding Assistant with inline completion";
-    public final static String SETTINGS_ENABLED_COMPLETION = "Enable Coding Assistant on Code Completion";
+    public static final String SETTINGS_CODIGA_ACCOUNT_SECTION_TITLE = "Codiga Account";
+    public static final String SETTINGS_TEST_API_BUTTON_TEXT = "Test API connection";
+    public static final String SETTINGS_GET_API_TOKEN_BUTTON_TEXT = "Get API token";
+    public static final String SETTINGS_API_TOKEN_LABEL = "API Token:";
+    public static final String SETTINGS_API_TOKEN_COMMENT = "Add your Codiga API key to use your recipes in your IDE.";
+    public static final String SETTINGS_SNIPPETS_VISIBILITY_PARAMETERS = "Default Snippets Search when logged in";
 
-    public final static String SETTINGS_SNIPPETS_VISIBILITY_ALL_SNIPPETS = "All Snippets";
-    public final static String SETTINGS_SNIPPETS_VISIBILITY_PUBLIC_SNIPPETS_ONLY = "Public Snippets Only";
-    public final static String SETTINGS_SNIPPETS_VISIBILITY_PRIVATE_ONLY = "Private Snippets Only";
-    public final static String SETTINGS_SNIPPETS_VISIBILITY_FAVORITE_ONLY = "Favorite Snippets Only";
+    //Enable completions
 
-    public final static String API_STATUS_TITLE = "API Connection status";
-    public final static String API_STATUS_TEXT_OK = "Connection Successful";
-    public final static String API_STATUS_TEXT_FAIL =
+    public static final String SETTINGS_CODE_AND_INLINE_COMPLETION_SECTION_TITLE = "Code and Inline Completion";
+    public static final String SETTINGS_ENABLED_CODIGA = "Enable Codiga";
+    public static final String SETTINGS_ENABLED_INLINE_COMPLETION = "Enable Coding Assistant with inline completion";
+    public static final String SETTINGS_ENABLED_COMPLETION = "Enable Coding Assistant on Code Completion";
+
+    //Snippet visibility
+
+    public static final String SETTINGS_SNIPPETS_VISIBILITY_ALL_SNIPPETS = "All Snippets";
+    public static final String SETTINGS_SNIPPETS_VISIBILITY_PUBLIC_SNIPPETS_ONLY = "Public Snippets Only";
+    public static final String SETTINGS_SNIPPETS_VISIBILITY_PRIVATE_ONLY = "Private Snippets Only";
+    public static final String SETTINGS_SNIPPETS_VISIBILITY_FAVORITE_ONLY = "Favorite Snippets Only";
+
+    //API status
+
+    public static final String API_STATUS_TITLE = "API Connection status";
+    public static final String API_STATUS_TEXT_OK = "Connection Successful";
+    public static final String API_STATUS_TEXT_FAIL =
         "Connection Failed. Check your access/secret keys and make sure you Apply changes before testing";
 
+    public static final String ANNOTATION_PREFIX = "Codiga";
 
-    public final static String ANNOTATION_PREFIX = "Codiga";
-
-
+    private UIConstants() {
+        //Utility class
+    }
 }


### PR DESCRIPTION
### Changes
- `AppSettingsComponent` and `AppSettingsConfigurable`
  - Fixed a few typos.
  - Removed an unused logger field.
  - Moved the Codiga completion related checkbox components into a `ButtonGroup`. This automatically makes sure that only one of the `RadioButton`s in that group can be selected at a time, instead of having to manually update each button's selected state.
  - **Bugfix**: there was an issue that when the settings page was opened with Codiga disabled, the code completion and inline completion checkboxes were still enabled.
  - Improved the settings UI.
  - Moved the checkbox and radiobutton labels into the constructor's of those components, instead of using a separate `JLabel` for each of them. This made both the UI and the code clearer.
- `StatusBar`
  - **Bugfix**: the status bar icon's tooltip text wasn't updated upon changin the Codiga enabled/disabled state.
- `UIConstants`
  - Added and reordered some keywords.
  - Added a few comments for better separate text groups.