### PR TITLE
Display error hint in the editor when a Rosie annotation fix can't be applied

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
@@ -6,13 +6,16 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
+import com.intellij.refactoring.util.CommonRefactoringUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.ThrowableRunnable;
 import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFix;
 import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFixEdit;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.model.rosie.RosieConstants.*;
@@ -37,23 +40,53 @@ public class RosieAnnotationFix extends RosieAnnotationIntentionBase {
         try {
             WriteCommandAction.writeCommandAction(project).run(
                 (ThrowableRunnable<Throwable>) () -> {
-                    Document document = editor.getDocument();
-                    for (RosieViolationFixEdit edit : this.rosieViolationFix.edits) {
-                        LOGGER.info(String.format("Applying fix %s content |%s|", edit.editType, edit.content));
-                        if (edit.editType.equalsIgnoreCase(ROSIE_FIX_ADD)) {
-                            document.insertString(edit.start.getOffset(editor), edit.content);
-                        }
-                        if (edit.editType.equalsIgnoreCase(ROSIE_FIX_UPDATE)) {
-                            document.replaceString(edit.start.getOffset(editor), edit.end.getOffset(editor), edit.content);
-                        }
-                        if (edit.editType.equalsIgnoreCase(ROSIE_FIX_REMOVE)) {
-                            document.deleteString(edit.start.getOffset(editor), edit.end.getOffset(editor));
+                    if (!hasInvalidEditOffset(project, editor, psiFile)) {
+                        Document document = editor.getDocument();
+                        for (RosieViolationFixEdit edit : this.rosieViolationFix.edits) {
+                            LOGGER.info(String.format("Applying fix %s content |%s|", edit.editType, edit.content));
+                            if (edit.editType.equalsIgnoreCase(ROSIE_FIX_ADD)) {
+                                document.insertString(edit.start.getOffset(editor), edit.content);
+                            }
+                            if (edit.editType.equalsIgnoreCase(ROSIE_FIX_UPDATE)) {
+                                document.replaceString(edit.start.getOffset(editor), edit.end.getOffset(editor), edit.content);
+                            }
+                            if (edit.editType.equalsIgnoreCase(ROSIE_FIX_REMOVE)) {
+                                document.deleteString(edit.start.getOffset(editor), edit.end.getOffset(editor));
+                            }
                         }
                     }
                 }
             );
+        } catch (CommonRefactoringUtil.RefactoringErrorHintException e) {
+            //Fall through, don't have to log anything. Showing the error hint in the editor is enough.
         } catch (Throwable e) {
-            LOGGER.error("cannot add in editor", e);
+            LOGGER.error("Cannot apply fix in editor.", e);
         }
     }
+
+    /**
+     * If the start/end offset for any edit, received from the rule configuration, is incorrect, and is outside the
+     * current file's range, we show an error, and don't apply the fix.
+     */
+    @VisibleForTesting
+    boolean hasInvalidEditOffset(@NotNull Project project, Editor editor, PsiFile psiFile) {
+        boolean hasInvalidOffset = true;
+        try {
+            TextRange fileRange = psiFile.getTextRange();
+            hasInvalidOffset = this.rosieViolationFix.edits
+                .stream()
+                .anyMatch(edit -> !fileRange.contains(edit.start.getOffset(editor)) || !fileRange.contains(edit.end.getOffset(editor)));
+        } catch (IndexOutOfBoundsException e) {
+            //Let it through, so that it can be handled by the 'hasInvalidOffset' check below.
+        }
+
+        if (hasInvalidOffset) {
+            CommonRefactoringUtil.showErrorHint(project, editor,
+                "Can't apply the fix due to invalid start/end offsets.",
+                "Can't Apply Fix",
+                null);
+        }
+        return hasInvalidOffset;
+    }
+
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFixTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFixTest.java
@@ -1,0 +1,167 @@
+package io.codiga.plugins.jetbrains.annotators;
+
+import com.intellij.psi.PsiFile;
+import com.intellij.refactoring.util.CommonRefactoringUtil;
+import io.codiga.plugins.jetbrains.model.rosie.RosiePosition;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFix;
+import io.codiga.plugins.jetbrains.model.rosie.RosieViolationFixEdit;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+
+import java.util.List;
+
+/**
+ * Integration test for {@link RosieAnnotationFix}.
+ */
+public class RosieAnnotationFixTest extends TestBase {
+
+    @Override
+    protected String getTestDataRelativePath() {
+        return TEST_DATA_BASE_PATH + "/rosieannotator";
+    }
+
+    //Insert
+
+    public void testTextInsertionFix() {
+        doTestAnnotationFix("text_insertion_fix.py", "Fix: Insert text",
+            "clasThis is the inserted texts Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    //Replace
+
+    public void testTextReplacementFixWithEditRangeMatchingViolationRange() {
+        doTestAnnotationFix("text_replacement_fix_ranges_matching.py", "Fix: Replace text",
+            "clasThis is the replacment textson:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextReplacementFixWithEditRangeNotMatchingViolationRange() {
+        doTestAnnotationFix("text_replacement_fix_ranges_not_matching.py", "Fix: Replace text",
+            "cThis is the replacement texts Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    //Delete
+
+    public void testTextRemovalFixWithEditRangeMatchingViolationRange() {
+        doTestAnnotationFix("text_removal_fix_ranges_matching.py", "Fix: Remove text",
+            "classon:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    public void testTextRemovalFixWithEditRangeNotMatchingViolationRange() {
+        doTestAnnotationFix("text_removal_fix_ranges_not_matching.py", "Fix: Remove text",
+            "cs Person:\n" +
+                "  def __init__(self, name):\n" +
+                "    self.name = name\n");
+    }
+
+    //Negative cases
+
+    public void testDoesntApplyFixWhenStartLineIsOutOfRange() {
+        PsiFile psiFile = myFixture.configureByFile("text_insertion_fix.py");
+        var fix = new RosieAnnotationFix(
+            new RosieViolationFix(
+                "Apply fix",
+                List.of(
+                    new RosieViolationFixEdit(
+                        new RosiePosition(6, 5), //start line is invalid
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ),
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 5),
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ))));
+
+        assertThrows(
+            CommonRefactoringUtil.RefactoringErrorHintException.class,
+            () -> fix.hasInvalidEditOffset(getProject(), myFixture.getEditor(), psiFile));
+    }
+
+    public void testDoesntApplyFixWhenStartColumnIsOutOfRange() {
+        PsiFile psiFile = myFixture.configureByFile("text_insertion_fix.py");
+        var fix = new RosieAnnotationFix(
+            new RosieViolationFix(
+                "Apply fix",
+                List.of(
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, -1), //start column is invalid
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ),
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 5),
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ))));
+
+        assertThrows(
+            CommonRefactoringUtil.RefactoringErrorHintException.class,
+            () -> fix.hasInvalidEditOffset(getProject(), myFixture.getEditor(), psiFile));
+    }
+
+    public void testDoesntApplyFixWhenEndLineIsOutOfRange() {
+        PsiFile psiFile = myFixture.configureByFile("text_insertion_fix.py");
+        var fix = new RosieAnnotationFix(
+            new RosieViolationFix(
+                "Apply fix",
+                List.of(
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 1),
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ),
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 5),
+                        new RosiePosition(6, 10), //end line is invalid
+                        "Content",
+                        "add"
+                    ))));
+
+        assertThrows(
+            CommonRefactoringUtil.RefactoringErrorHintException.class,
+            () -> fix.hasInvalidEditOffset(getProject(), myFixture.getEditor(), psiFile));
+    }
+
+    public void testDoesntApplyFixWhenEndColumnIsOutOfRange() {
+        PsiFile psiFile = myFixture.configureByFile("text_insertion_fix.py");
+        var fix = new RosieAnnotationFix(
+            new RosieViolationFix(
+                "Apply fix",
+                List.of(
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 1),
+                        new RosiePosition(3, 10),
+                        "Content",
+                        "add"
+                    ),
+                    new RosieViolationFixEdit(
+                        new RosiePosition(1, 5),
+                        new RosiePosition(6, -2), //end column is invalid
+                        "Content",
+                        "add"
+                    ))));
+
+        assertThrows(
+            CommonRefactoringUtil.RefactoringErrorHintException.class,
+            () -> fix.hasInvalidEditOffset(getProject(), myFixture.getEditor(), psiFile));
+    }
+
+    private void doTestAnnotationFix(String filePath, String fixName, String afterText) {
+        myFixture.configureByFile(filePath);
+        myFixture.doHighlighting();
+        myFixture.launchAction(myFixture.findSingleIntention(fixName));
+        myFixture.checkResult(afterText);
+    }
+}

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
@@ -36,43 +36,6 @@ public class RosieAnnotatorTest extends TestBase {
         doTestAnnotations("no_highlight_for_end_offset_outside.py");
     }
 
-    //Rosie code quick fixes
-
-    public void testTextInsertionFix() {
-        doTestAnnotationFix("text_insertion_fix.py", "Fix: Insert text",
-            "clasThis is the inserted texts Person:\n" +
-                "  def __init__(self, name):\n" +
-                "    self.name = name\n");
-    }
-
-    public void testTextReplacementFixWithEditRangeMatchingViolationRange() {
-        doTestAnnotationFix("text_replacement_fix_ranges_matching.py", "Fix: Replace text",
-            "clasThis is the replacment textson:\n" +
-                "  def __init__(self, name):\n" +
-                "    self.name = name\n");
-    }
-
-    public void testTextReplacementFixWithEditRangeNotMatchingViolationRange() {
-        doTestAnnotationFix("text_replacement_fix_ranges_not_matching.py", "Fix: Replace text",
-            "cThis is the replacement texts Person:\n" +
-                "  def __init__(self, name):\n" +
-                "    self.name = name\n");
-    }
-
-    public void testTextRemovalFixWithEditRangeMatchingViolationRange() {
-        doTestAnnotationFix("text_removal_fix_ranges_matching.py", "Fix: Remove text",
-            "classon:\n" +
-                "  def __init__(self, name):\n" +
-                "    self.name = name\n");
-    }
-
-    public void testTextRemovalFixWithEditRangeNotMatchingViolationRange() {
-        doTestAnnotationFix("text_removal_fix_ranges_not_matching.py", "Fix: Remove text",
-            "cs Person:\n" +
-                "  def __init__(self, name):\n" +
-                "    self.name = name\n");
-    }
-
     //Disable Rosie analysis comment quick fixes
 
     public void testAddsCodigaDisableCommentToTopLevelElementInPython() {


### PR DESCRIPTION
### Changes
- `RosieAnnotationFix`
  - If any offset in any edits of a `RosieViolationFix` is out of the files range and would result in an `IndexOutOfBoundsException`, we should an error hint in the editor, at the place where the quick fix was invoked.
- Moved some tests from `RosieAnnotatorTest` to `RosieAnnotationFixTest`.

Said error hint:
![quick_fix_error_hint](https://user-images.githubusercontent.com/5739987/199664344-48b18dd3-060f-4307-9f5a-0f31785a0232.png)