### PR TITLE
Update Rosie rule name

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCacheValue.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCacheValue.java
@@ -57,7 +57,7 @@ public final class RosieRulesCacheValue {
         public RuleWithNames(String rulesetName, GetRulesetsForClientQuery.Rule rule) {
             this.rulesetName = rulesetName;
             this.ruleName = rule.name();
-            this.rosieRule = new RosieRule(rule);
+            this.rosieRule = new RosieRule(rulesetName, rule);
         }
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRule.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/model/rosie/RosieRule.java
@@ -46,8 +46,8 @@ public class RosieRule {
         }
     }
 
-    public RosieRule(GetRulesetsForClientQuery.Rule rule) {
-        this.id = rule.id().toString();
+    public RosieRule(String rulesetName, GetRulesetsForClientQuery.Rule rule) {
+        this.id = rulesetName + "/" + rule.name();
         this.contentBase64 = rule.content();
         this.language = rule.language().rawValue();
         this.type = rule.ruleType().rawValue();

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCacheTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieRulesCacheTest.java
@@ -22,7 +22,9 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesets.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 3, "10", "11", "12");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            3,
+            "python-ruleset/python_rule_1", "python-ruleset/python_rule_2", "python-ruleset/python_rule_3");
     }
 
     public void testStoresRulesFromSingleRulesetForAMultipleLanguagesInEmptyCache() {
@@ -32,8 +34,12 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesets.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 2, "10", "12");
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA), 1, "20");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            2,
+            "mixed-ruleset/python_rule_1", "mixed-ruleset/python_rule_3");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA),
+            1,
+            "mixed-ruleset/java_rule_1");
     }
 
     public void testStoresRulesFromMultipleRulesetsForSingleLanguageGroupedByLanguageInEmptyCache() {
@@ -47,7 +53,9 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesets.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 3, "10", "11", "12");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            3,
+            "python-ruleset/python_rule_2", "python-ruleset-2/python_rule_3", "python-ruleset/python_rule_1");
     }
 
     public void testStoresRulesFromMultipleRulesetsForMultipleLanguagesGroupedByLanguageInEmptyCache() {
@@ -61,8 +69,12 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesets.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 2, "30", "31");
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA), 1, "20");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            2,
+            "python-ruleset/python_rule_5", "mixed-ruleset/python_rule_4");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA),
+            1,
+            "mixed-ruleset/java_rule_1");
     }
 
     public void testOverridesCacheWithNewRules() {
@@ -74,8 +86,12 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesets.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 2, "30", "31");
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA), 1, "20");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            2,
+            "python-ruleset/python_rule_5", "mixed-ruleset/python_rule_4");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA),
+            1,
+            "mixed-ruleset/java_rule_1");
 
         //Cache refresh
 
@@ -84,7 +100,9 @@ public class RosieRulesCacheTest extends TestBase {
 
         cache.updateCacheFrom(rulesetsNew.get());
 
-        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON), 3, "10", "11", "12");
+        validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON),
+            3,
+            "python-ruleset/python_rule_1", "python-ruleset/python_rule_2", "python-ruleset/python_rule_3");
         validateRuleCountAndRuleIds(cache.getRosieRulesForLanguage(LanguageEnumeration.JAVA), 0);
     }
 


### PR DESCRIPTION
### Changes
- Updated the `RosieRule` id, so that it is sent in the form of ruleset/rulename, e.g. *python-best-practices/some-python-rule*.