### PR TITLE
Move ruleset name caching implementation from CachedValueProvider

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/starter/RosieStartupActivity.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/RosieStartupActivity.java
@@ -159,8 +159,9 @@ public class RosieStartupActivity implements StartupActivity {
      */
     private void startRosieRulesCacheUpdater(@NotNull Project project) {
         var updateHandler = new RosieRulesCacheUpdateHandler(RosieRulesCache.getInstance(project), project);
+        updateHandler.initRulesets();
         var cacheUpdater = AppExecutorUtil.getAppScheduledExecutorService()
-            .scheduleWithFixedDelay(updateHandler::handleCacheUpdate, 1L, 10L, SECONDS);
+            .scheduleWithFixedDelay(updateHandler::handleCacheUpdate, 2L, 10L, SECONDS);
 
         rosieCacheUpdaters.put(project, cacheUpdater);
 


### PR DESCRIPTION
### Changed
- Removed the `CachedValueProvider` based caching of the ruleset names because I encountered a invalid cached PSI/`YAMLFile` instance related problem, that I had no `CachedValueProvider` based solution for.
- The cache implementation is moved to `RosieRulesCache` from `CodigaConfigFileUtil`.