### PR TITLE
Add rule names to the Rosie quick fix titles

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
@@ -25,7 +25,7 @@ public class AnnotationFixOpenBrowser extends RosieAnnotationIntentionBase {
 
     @Override
     public @IntentionName @NotNull String getText() {
-        return "See on Codiga Hub: rate or comment";
+        return String.format("See rule '%s' on the Codiga Hub", rosieAnnotation.getRuleName());
     }
 
     /**

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/DisableRosieAnalysisFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/DisableRosieAnalysisFix.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
 import io.codiga.plugins.jetbrains.graphql.LanguageUtils;
+import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -25,14 +26,16 @@ import org.jetbrains.annotations.NotNull;
  * NOTE: the correct indentation is applied only when the IDE itself recognizes the language of the file,
  * otherwise the comment is added at the beginning of the new line.
  */
+@RequiredArgsConstructor
 public class DisableRosieAnalysisFix extends RosieAnnotationIntentionBase {
 
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
     private static final String CODIGA_DISABLE = "codiga-disable";
+    private final String ruleName;
 
     @Override
     public @IntentionName @NotNull String getText() {
-        return "Remove this warning";
+        return String.format("Remove error '%s'", ruleName);
     }
 
     @Override

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -191,7 +191,7 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
             annotationBuilder.withFix(new RosieAnnotationFix(rosieViolationFix));
         }
         annotationBuilder
-            .withFix(new DisableRosieAnalysisFix())
+            .withFix(new DisableRosieAnalysisFix(annotation.getRuleName()))
             .withFix(new AnnotationFixOpenBrowser(annotation));
 
 

--- a/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotatorTest.java
@@ -39,7 +39,7 @@ public class RosieAnnotatorTest extends TestBase {
     //Disable Rosie analysis comment quick fixes
 
     public void testAddsCodigaDisableCommentToTopLevelElementInPython() {
-        doTestAnnotationFix("add_top_level_disable_codiga.py", "Remove this warning",
+        doTestAnnotationFix("add_top_level_disable_codiga.py", "Remove error 'single_rule'",
             "# codiga-disable\n" +
                 "class PersonWithAddress:\n" +
                 "  def __init__(self, name, age, address):\n" +
@@ -49,7 +49,7 @@ public class RosieAnnotatorTest extends TestBase {
     }
 
     public void testAddsCodigaDisableCommentToNestedElementInPython() {
-        doTestAnnotationFix("add_nested_disable_codiga.py", "Remove this warning",
+        doTestAnnotationFix("add_nested_disable_codiga.py", "Remove error 'single_rule'",
             "class PersonWithAddress:\n" +
                 "  def __init__(self, name, age, long_address):\n" +
                 "    self.name = name\n" +
@@ -59,14 +59,14 @@ public class RosieAnnotatorTest extends TestBase {
     }
 
     public void testAddsCodigaDisableCommentToTopLevelElementInJava() {
-        doTestAnnotationFix("add_top_level_disable_codiga.java", "Remove this warning",
+        doTestAnnotationFix("add_top_level_disable_codiga.java", "Remove error 'single_rule'",
             "// codiga-disable\n" +
                 "public class SomeClass {\n" +
                 "}");
     }
 
     public void testAddsCodigaDisableCommentToNestedElementInJava() {
-        doTestAnnotationFix("add_nested_disable_codiga.java", "Remove this warning",
+        doTestAnnotationFix("add_nested_disable_codiga.java", "Remove error 'single_rule'",
             "public class SomeClass {\n" +
                 "    void method() {\n" +
                 "        boolean isPassing = true;\n" +


### PR DESCRIPTION
### Changes
- Updated the titles of `AnnotationfixOpenBrowser` and `DisableRosieAnalysisFix`, including adding the associated rules' names to them.