### PR TITLE
Add web references to ruleset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 ### Added
+- [#191](https://github.com/codiga/jetbrains-plugin/issues/191): Users can now navigate from codiga.yml to the rulesets on Codiga Hub
+  via Ctrl + clicking on ruleset names.
 
 ### Changed
 

--- a/src/main/java/io/codiga/plugins/jetbrains/reference/CodigaRulesetReferenceContributor.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/reference/CodigaRulesetReferenceContributor.java
@@ -1,0 +1,46 @@
+package io.codiga.plugins.jetbrains.reference;
+
+import static com.intellij.patterns.PlatformPatterns.psiElement;
+import static com.intellij.patterns.PlatformPatterns.psiFile;
+import static io.codiga.plugins.jetbrains.rosie.CodigaConfigFileUtil.isRulesetNameValid;
+
+import com.intellij.openapi.paths.WebReference;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceProvider;
+import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.util.ProcessingContext;
+import io.codiga.plugins.jetbrains.rosie.CodigaConfigFileUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLFile;
+import org.jetbrains.yaml.psi.YAMLSequenceItem;
+import org.jetbrains.yaml.psi.impl.YAMLPlainTextImpl;
+
+/**
+ * Provides a {@link WebReference} for all valid ruleset names in the Codiga config file,
+ * so that users can navigate to the rulesets on Codiga Hub via a simple Ctrl+click.
+ */
+public class CodigaRulesetReferenceContributor extends PsiReferenceContributor {
+
+    private static final PsiElementPattern.Capture<YAMLPlainTextImpl> CODIGA_RULESET_NAME =
+        psiElement(YAMLPlainTextImpl.class)
+            .withParent((psiElement(YAMLSequenceItem.class)))
+            .inFile(psiFile(YAMLFile.class)
+                .withName(CodigaConfigFileUtil.CODIGA_CONFIG_FILE_NAME));
+
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar psiReferenceRegistrar) {
+        psiReferenceRegistrar.registerReferenceProvider(
+            CODIGA_RULESET_NAME,
+            new PsiReferenceProvider() {
+                @Override
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                    return isRulesetNameValid(element.getText())
+                        ? new PsiReference[]{new WebReference(element, "https://app.codiga.io/hub/ruleset/" + element.getText())}
+                        : PsiReference.EMPTY_ARRAY;
+                }
+            });
+    }
+}

--- a/src/main/java/io/codiga/plugins/jetbrains/rosie/CodigaConfigFileUtil.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/rosie/CodigaConfigFileUtil.java
@@ -25,6 +25,7 @@ import java.util.Optional;
  */
 public final class CodigaConfigFileUtil {
 
+    private static final String CODIGA_RULESET_NAME_PATTERN = "^[a-z0-9][a-z0-9-]{4,}$";
     private static final String RULESETS = "rulesets";
     public static final String CODIGA_CONFIG_FILE_NAME = "codiga.yml";
 
@@ -96,6 +97,10 @@ public final class CodigaConfigFileUtil {
             }
         }
         return List.of();
+    }
+
+    public static boolean isRulesetNameValid(String rulesetName) {
+        return rulesetName.matches(CODIGA_RULESET_NAME_PATTERN);
     }
 
     private CodigaConfigFileUtil() {

--- a/src/main/resources/META-INF/yaml-features.xml
+++ b/src/main/resources/META-INF/yaml-features.xml
@@ -12,6 +12,10 @@
 
         <applicationService
                 serviceImplementation="io.codiga.plugins.jetbrains.actions.snippet_search.service.YamlFileTypeService"/>
+
+        <psi.referenceContributor
+                language="yaml"
+                implementation="io.codiga.plugins.jetbrains.reference.CodigaRulesetReferenceContributor"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript.JsonSchema">

--- a/src/test/java/io/codiga/plugins/jetbrains/reference/CodigaRulesetReferenceContributorTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/reference/CodigaRulesetReferenceContributorTest.java
@@ -1,0 +1,38 @@
+package io.codiga.plugins.jetbrains.reference;
+
+import com.intellij.openapi.paths.WebReference;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import io.codiga.plugins.jetbrains.testutils.TestBase;
+
+/**
+ * Integration test for {@link CodigaRulesetReferenceContributor}.
+ */
+public class CodigaRulesetReferenceContributorTest extends TestBase {
+
+    public void testAddsReferenceForValidRulesetName() {
+        myFixture.configureByText("codiga.yml",
+            "rulesets:\n" +
+                "  - valid-ruleset\n" +
+                "  - oth<caret>er-valid-ruleset");
+
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        PsiReference[] references = element.getReferences();
+
+        assertSize(1, references);
+        assertTrue(references[0] instanceof WebReference);
+        assertEquals(((WebReference) references[0]).getUrl(), "https://app.codiga.io/hub/ruleset/other-valid-ruleset");
+    }
+
+    public void testDoesntAddReferenceForInvalidRulesetName() {
+        myFixture.configureByText("codiga.yml",
+            "rulesets:\n" +
+                "  - valid-ruleset\n" +
+                "  - INval<caret>id-rule!!set");
+
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+        PsiReference[] references = element.getReferences();
+
+        assertEmpty(references);
+    }
+}


### PR DESCRIPTION
### Changes:
- Introduced `CodigaRulesetReferenceContributor` that adds a `WebReference` to ruleset names. `WebReference` makes it possible to open a URL in the browser upon clicking on an element.
  - Reference is not added to invalid ruleset names.