### PR TITLE
Use application settings to store the api token

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/Constants.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/Constants.java
@@ -34,7 +34,4 @@ public class Constants {
 
     // PHP constants
     public static final String PHP_DEPENDENCY_FILE = "composer.json";
-
-    public static final String CREDENTIALS_SERVICE = "Codiga";
-    public static final String CREDENTIALS_KEY = "Api Token";
 }


### PR DESCRIPTION
### Changes
- Removed the `PasswordSafe` based solution, and move the api token to `AppSettingsState`.
  - Although `PasswordUtil` is deprecated and `PasswordSafe` is recommended to be used instead, I use this util for encoding/decoding, since it is a less common type of chips to lock that door with, than base64.