### PR TITLE
Handle UnknownHostException in RosieApiImpl

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/rosie/RosieApiImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/rosie/RosieApiImpl.java
@@ -23,6 +23,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -115,11 +116,14 @@ public class RosieApiImpl implements RosieApi {
             }
             client.close();
             return annotations;
+        } catch (UnknownHostException unknownHostException) {
+            LOGGER.warn("[RosieApiImpl] Could not connect to analysis.codiga.io.", unknownHostException);
+            return List.of();
         } catch (IOException unsupportedEncodingException) {
-            LOGGER.error("[RosieImpl] ClientProtocolException", unsupportedEncodingException);
+            LOGGER.warn("[RosieApiImpl] ClientProtocolException", unsupportedEncodingException);
             return List.of();
         } catch (JsonSyntaxException jsonSyntaxException) {
-            LOGGER.warn("[RosieImpl] cannot decode JSON", jsonSyntaxException);
+            LOGGER.warn("[RosieApiImpl] cannot decode JSON", jsonSyntaxException);
             return List.of();
         }
     }


### PR DESCRIPTION
### Changes
- `RosieApiImpl`
  - Although `IOException` already handled `UnknownHostException`, I added a separate catch block to provide a more specific error message in that case.
  - Moved the `IOException` logging too to `warn()` level to match the levels in the other two catch blocks.