### PR TITLE
Update pluginUntilBuild to support IJ-2022.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@ pluginGroup=codiga.io.plugins
 pluginName=codiga-jetbrains-plugin
 pluginVersion=1.8.1
 pluginSinceBuild=213
-pluginUntilBuild=222.*
+pluginUntilBuild=223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions=2021.3, 2022.1, 2022.2
+pluginVerifierIdeVersions=2021.3, 2022.1, 2022.2, 2022.3
 platformType=IC
 platformVersion=2021.3
 platformDownloadSources=true


### PR DESCRIPTION
### Changes
- Updated the `pluginUntilBuild` in gradle.properties to 223.*, so that we support IDE version 2022.3 as well.