### PR TITLE
Disable inline and code completion by default

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsState.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/settings/application/AppSettingsState.java
@@ -29,9 +29,9 @@ public class AppSettingsState implements PersistentStateComponent<AppSettingsSta
     @Tag
     private String fingerprint = "";
     @Tag
-    private Boolean useCompletion = true;
+    private Boolean useCompletion = false;
     @Tag
-    private Boolean useInlineCompletion = true;
+    private Boolean useInlineCompletion = false;
     @Tag
     private Boolean showDialogApiNotification = true;
     @Tag

--- a/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/assistant/transformers/VariableIndentationTest.java
@@ -13,12 +13,14 @@ public class VariableIndentationTest extends TestBase {
 
   public void testIndentation() {
     AppSettingsState.getInstance().setUseInlineCompletion(false);
+    AppSettingsState.getInstance().setUseCompletion(true);
+
     myFixture.testCompletionVariants("spawn_thread.rs");
     myFixture.type(".spawn");
     myFixture.complete(CompletionType.BASIC);
-
-
     myFixture.checkResultByFile("spawn_thread_indent_result.rs");
-    AppSettingsState.getInstance().setUseInlineCompletion(true);
+
+    AppSettingsState.getInstance().setUseInlineCompletion(false);
+    AppSettingsState.getInstance().setUseCompletion(false);
   }
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/CodigaCompletionProviderTest.java
@@ -13,10 +13,14 @@ public class CodigaCompletionProviderTest extends TestBase {
 
     public void testAcceptRecipeSuggestion() {
         AppSettingsState.getInstance().setUseInlineCompletion(true);
+        AppSettingsState.getInstance().setUseCompletion(true);
+
         myFixture.testCompletionVariants("spawn_thread.rs");
         myFixture.type(".spawn");
         myFixture.complete(CompletionType.BASIC);
         myFixture.checkResultByFile("spawn_thread_accept_result.rs");
-        AppSettingsState.getInstance().setUseInlineCompletion(true);
+
+        AppSettingsState.getInstance().setUseInlineCompletion(false);
+        AppSettingsState.getInstance().setUseCompletion(false);
     }
 }

--- a/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/completion/inline/InlineCompletionTest.java
@@ -13,6 +13,12 @@ public class InlineCompletionTest extends TestBase {
         return "src/test/data/completion/inline";
     }
 
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        AppSettingsState.getInstance().setUseInlineCompletion(true);
+    }
+
     //Multiple snippets
 
     public void testAcceptFirstSnippet() {


### PR DESCRIPTION
### Changes
- `AppSettingsState`
  - Set the default value of both inline the shortcuts completion to `false`/disabled.