### PR TITLE
Check if project is disposed before starting the shortcut cache updater.

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
@@ -155,7 +155,15 @@ public class AppStarter implements StartupActivity {
      * Starts the shortcut cache refresher.
      */
     private void startShortcutCacheUpdater(@NotNull Project project) {
+        if (project.isDisposed()) {
+            return;
+        }
+
         AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(() -> {
+            if (project.isDisposed()) {
+                return;
+            }
+
             final AppSettingsState settings = AppSettingsState.getInstance();
             if (settings == null) {
                 return;


### PR DESCRIPTION
### Changes
- `AppStarter`
  - Added `project.isDisposed()` checks both before starting the updater, and for when the updater is already running.