### PR TITLE
fix: user-agent for GraphQL API

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApiImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/graphql/CodigaApiImpl.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
+import static io.codiga.plugins.jetbrains.graphql.Constants.USER_AGENT;
+import static io.codiga.plugins.jetbrains.utils.UserAgentUtils.getUserAgent;
 
 /**
  * This class implements the Codiga API, which is a GraphQL API.
@@ -40,6 +42,8 @@ public final class CodigaApiImpl implements CodigaApi {
         .serverUrl(Constants.ENDPOINT_URL)
         .build();
 
+
+
     /**
      * Set the header with access/secret keys so that we do an authenticated
      * request. to the API.
@@ -58,10 +62,12 @@ public final class CodigaApiImpl implements CodigaApi {
             return RequestHeaders
                 .builder()
                 .addHeader(Constants.API_TOKEN_HEADER, apiToken)
+                .addHeader(USER_AGENT, getUserAgent())
                 .build();
         }
         return RequestHeaders
             .builder()
+            .addHeader(USER_AGENT, getUserAgent())
             .build();
     }
 

--- a/src/main/java/io/codiga/plugins/jetbrains/graphql/Constants.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/graphql/Constants.java
@@ -9,4 +9,5 @@ public final class Constants {
     public static final String ACCESS_KEY_HEADER = "X-Access-Key";
     public static final String SECRET_KEY_HEADER = "X-Secret-Key";
     public static final String API_TOKEN_HEADER = "X-Api-Token";
+    public static final String USER_AGENT = "User-Agent";
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/rosie/RosieApiImpl.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/rosie/RosieApiImpl.java
@@ -2,7 +2,6 @@ package io.codiga.plugins.jetbrains.rosie;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
-import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -30,6 +29,7 @@ import java.util.List;
 
 import static io.codiga.plugins.jetbrains.Constants.LOGGER_NAME;
 import static io.codiga.plugins.jetbrains.utils.RosieUtils.getRosieLanguage;
+import static io.codiga.plugins.jetbrains.utils.UserAgentUtils.getUserAgent;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -49,13 +49,6 @@ public class RosieApiImpl implements RosieApi {
 
     public RosieApiImpl() {
         // no constructor instructions
-    }
-
-    private String getUserAgent() {
-        return String.format("%s %s %s",
-            ApplicationInfo.getInstance().getFullApplicationName(),
-            ApplicationInfo.getInstance().getMajorVersion(),
-            ApplicationInfo.getInstance().getMinorVersion());
     }
 
     @Override

--- a/src/main/java/io/codiga/plugins/jetbrains/utils/UserAgentUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/utils/UserAgentUtils.java
@@ -1,0 +1,16 @@
+package io.codiga.plugins.jetbrains.utils;
+
+import com.intellij.openapi.application.ApplicationInfo;
+
+public class UserAgentUtils {
+    /**
+     * Return the user-agent for the current product.
+     * @return
+     */
+    public static String getUserAgent() {
+        return String.format("%s/%s.%s",
+            ApplicationInfo.getInstance().getVersionName(),
+            ApplicationInfo.getInstance().getMajorVersion(),
+            ApplicationInfo.getInstance().getMinorVersion());
+    }
+}


### PR DESCRIPTION
**Problem**

The user-agent of the GraphQL API client is `okhttp`, which is taken from the internal HTTP client from the GraphQL library. We want to make sure we use the `User-Agent` that is used for Rosie.

**Solution**
1. Introduce a class to get the user-agent
2. Use the user-agent and apply it to the graphql client and rosie client altogether.
