### PR TITLE
Annotation and rulesets bug fixes

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -175,8 +175,8 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
         TextRange annotationRange = new TextRange(annotation.getStart(), annotation.getEnd());
         LOGGER.debug("annotation range: " + annotationRange);
 
-        if (!fileRange.contains(annotationRange.getEndOffset()) ||
-            !fileRange.contains(annotationRange.getStartOffset())) {
+        if (!fileRange.containsOffset(annotationRange.getEndOffset()) ||
+            !fileRange.containsOffset(annotationRange.getStartOffset())) {
             LOGGER.debug("range outside of the scope");
             return;
         }

--- a/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandler.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandler.java
@@ -43,7 +43,7 @@ public final class RosieRulesCacheUpdateHandler {
         if (!isCodigaConfigFileExist(codigaConfigFile)) {
             rulesCache.clear();
             //Since the config file no longer exist, its modification stamp is reset too
-            rulesCache.setConfigFileModificationStamp(0);
+            rulesCache.setConfigFileModificationStamp(-1);
             return;
         }
 

--- a/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/starter/RosieRulesCacheUpdateHandlerTest.java
@@ -129,8 +129,10 @@ public class RosieRulesCacheUpdateHandlerTest extends TestBase {
         myFixture.copyFileToProject("codiga.yml");
 
         RosieRulesCache rulesCache = RosieRulesCache.getInstance(getProject());
+        rulesCache.setRulesetNames(List.of("singleRulesetSingleLanguage"));
         rulesCache.updateCacheFrom(RulesetsForClientTestSupport.singleRulesetMultipleLanguages());
         rulesCache.setLastUpdatedTimeStamp(101L);
+        rulesCache.setConfigFileModificationStamp(0);
 
         assertSize(2, rulesCache.getRosieRulesForLanguage(LanguageEnumeration.PYTHON));
         assertEquals(101, rulesCache.getLastUpdatedTimeStamp());


### PR DESCRIPTION
### Changes
- Updated the range containment check logic in `RosieAnnotator` so that the end offset is inclusive.
  - This prevented showing annotations that ended at the document end.
- Updated the default config file modification stamp value in `RosieRulesCacheUpdateHandler`.
  - This prevented parsing the Codiga config file when a project was opened without a config file, and the file was created later e.g. via the default rulesets notification.