### PR TITLE
Various bugfixes

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/actions/ActionUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/actions/ActionUtils.java
@@ -1,6 +1,7 @@
 package io.codiga.plugins.jetbrains.actions;
 
 import com.intellij.ide.DataManager;
+import com.intellij.injected.editor.VirtualFileWindow;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -76,7 +77,14 @@ public class ActionUtils {
     }
 
     public final static String getUnitRelativeFilenamePathFromEditorForVirtualFile(@NotNull Project project, @NotNull VirtualFile virtualFile) {
-        String canonicalPath = virtualFile.getPath();
+        /*
+         * Language can be injected in string literals. See https://www.jetbrains.com/help/idea/using-language-injections.html.
+         * In that case the language injected code is handled in an underlying VirtualFileWindow, which returns a different a path from `getPath()`,
+         * thus we have to get the path of the file into which it is injected.
+         */
+        String canonicalPath = virtualFile instanceof VirtualFileWindow
+            ? ((VirtualFileWindow) virtualFile).getDelegate().getPath()
+            : virtualFile.getPath();
         String projectPath = project.getBasePath();
 
         String relativePath = canonicalPath.replace(projectPath, "");

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/AnnotationFixOpenBrowser.java
@@ -32,7 +32,7 @@ public class AnnotationFixOpenBrowser extends RosieAnnotationIntentionBase {
      * Opens the rule's page on Codiga Hub for this particular violation.
      */
     @Override
-    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+    public void doInvoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
         try {
             BrowserUtil.browse(getUrlString());
         } catch (Exception e) {

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/DisableRosieAnalysisFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/DisableRosieAnalysisFix.java
@@ -39,7 +39,7 @@ public class DisableRosieAnalysisFix extends RosieAnnotationIntentionBase {
     }
 
     @Override
-    public void invoke(@NotNull Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
+    public void doInvoke(@NotNull Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
         AnAction action = ActionManager.getInstance().getAction("EditorStartNewLineBefore");
         if (!(action instanceof StartNewLineBeforeAction)) {
             //This shouldn't happen since the action is available on platform-level

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationFix.java
@@ -36,7 +36,7 @@ public class RosieAnnotationFix extends RosieAnnotationIntentionBase {
     }
 
     @Override
-    public void invoke(@NotNull Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
+    public void doInvoke(@NotNull Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
         try {
             WriteCommandAction.writeCommandAction(project).run(
                 (ThrowableRunnable<Throwable>) () -> {

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationIntentionBase.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotationIntentionBase.java
@@ -3,6 +3,7 @@ package io.codiga.plugins.jetbrains.annotators;
 import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.codeInspection.util.IntentionFamilyName;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.impl.ImaginaryEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
@@ -26,4 +27,23 @@ public abstract class RosieAnnotationIntentionBase implements IntentionAction {
     public boolean startInWriteAction() {
         return true;
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Imaginary editors, like {@link com.intellij.codeInsight.intention.impl.preview.IntentionPreviewEditor},
+     * are excluded, there the intention is not invoked.
+     */
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile psiFile) {
+        if (editor instanceof ImaginaryEditor)
+            return;
+
+        doInvoke(project, editor, psiFile);
+    }
+
+    /**
+     * Performs the actual intention action logic.
+     */
+    protected abstract void doInvoke(@NotNull Project project, Editor editor, PsiFile psiFile);
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/annotators/RosieAnnotator.java
@@ -168,8 +168,12 @@ public class RosieAnnotator extends ExternalAnnotator<RosieAnnotatorInformation,
         @NotNull final RosieAnnotationJetBrains annotation,
         @NotNull AnnotationHolder holder) {
 
-        final String message = String.format("%s (%s)", annotation.getMessage(), ANNOTATION_PREFIX);
+        //If the annotation starts later than it ends, don't annotate
+        if (annotation.getStart() > annotation.getEnd()) {
+            return;
+        }
 
+        final String message = String.format("%s (%s)", annotation.getMessage(), ANNOTATION_PREFIX);
         final TextRange fileRange = psiFile.getTextRange();
 
         TextRange annotationRange = new TextRange(annotation.getStart(), annotation.getEnd());

--- a/src/test/java/io/codiga/plugins/jetbrains/rosie/RosieApiTest.java
+++ b/src/test/java/io/codiga/plugins/jetbrains/rosie/RosieApiTest.java
@@ -91,11 +91,20 @@ public class RosieApiTest implements RosieApi {
             "WARNING",
             "BEST_PRACTICE",
             Collections.emptyList());
+        //To test that a violation whose start offset is greater than its end offset, is not annotated
+        var rosieViolationWarningStartGtEnd = new RosieViolation(
+            "warning_violation_start_gt_end",
+            new RosiePosition(1, 3),
+            new RosiePosition(1, 1),
+            "WARNING",
+            "BEST_PRACTICE",
+            Collections.emptyList());
 
         return List.of(
             new RosieAnnotation("critical_rule", "ruleset_name", rosieViolationCritical),
             new RosieAnnotation("error_rule", "ruleset_name", rosieViolationError),
-            new RosieAnnotation("warning_rule", "ruleset_name", rosieViolationWarning)
+            new RosieAnnotation("warning_rule", "ruleset_name", rosieViolationWarning),
+            new RosieAnnotation("warning_rule_start_gt_end", "ruleset_name", rosieViolationWarningStartGtEnd)
         );
     }
 


### PR DESCRIPTION
### Changes
- Fixed an exception during `TextRange` creation in `RosieAnnotator` when an annotation's start offset is greater than its offset.
- Excluded imaginary editors from the Rosie quick fixes. This is to fix Rollbar item 46.
- Fixed #203 