### PR TITLE
Add default ruleset suggestions for JavaScript and TypeScript files.

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/graphql/LanguageUtils.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/graphql/LanguageUtils.java
@@ -6,6 +6,9 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.util.Map;
 
+/**
+ * Utility for file name and file extension based language retrieval.
+ */
 public final class LanguageUtils {
 
     private final static Map<String, LanguageEnumeration> EXTENSION_TO_LANGUAGE = ImmutableMap.<String, LanguageEnumeration>builder()
@@ -63,6 +66,13 @@ public final class LanguageUtils {
         // do not instantiate
     }
 
+    /**
+     * Returns the language based on the argument file name.
+     *
+     * @param filename the file name, including its extension
+     * @return the language if supported, {@code LanguageEnumeration.DOCKER} if the file name starts with "docker",
+     * or equals to "dockerfile", or {@code LanguageEnumeration.UNKNOWN} if the file extension is not available or not supported
+     */
     public static LanguageEnumeration getLanguageFromFilename(final String filename) {
         String extension;
         try {
@@ -75,6 +85,16 @@ public final class LanguageUtils {
             return LanguageEnumeration.DOCKER;
         }
 
+        return EXTENSION_TO_LANGUAGE.getOrDefault(extension, LanguageEnumeration.UNKNOWN);
+    }
+
+    /**
+     * Returns the language for the argument file extension.
+     *
+     * @param extension The file extension. Should be specified without the leading dot, e.g. "py", "yaml".
+     * @return the language, or {@code LanguageEnumeration.UNKNOWN} if the file extension is not supported
+     */
+    public static LanguageEnumeration getLanguageFromExtension(String extension) {
         return EXTENSION_TO_LANGUAGE.getOrDefault(extension, LanguageEnumeration.UNKNOWN);
     }
 }

--- a/src/main/java/io/codiga/plugins/jetbrains/rosie/CodigaRulesetConfigs.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/rosie/CodigaRulesetConfigs.java
@@ -1,5 +1,23 @@
 package io.codiga.plugins.jetbrains.rosie;
 
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ModuleRootModel;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import io.codiga.api.type.LanguageEnumeration;
+import io.codiga.plugins.jetbrains.graphql.LanguageUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * Provides default ruleset configurations for the Codiga config file.
  *
@@ -7,11 +25,79 @@ package io.codiga.plugins.jetbrains.rosie;
  */
 public final class CodigaRulesetConfigs {
 
-    public static final String DEFAULT_PYTHON_RULESET_CONFIG =
+    /**
+     * This id comes via {@code com.jetbrains.python.sdk.PythonSdkType},
+     * from {@code com.jetbrains.python.PyNames#PYTHON_SDK_ID_NAME}.
+     */
+    private static final String PYTHON_SDK_ID_NAME = "Python SDK";
+    /**
+     * File extensions associated to the currently supported Rosie languages.
+     */
+    private static final List<String> FILE_EXTENSIONS = List.of("py", "js", "jsx", "ts", "tsx");
+
+    private static final String DEFAULT_PYTHON_RULESET_CONFIG =
         "rulesets:\n" +
             "  - python-security\n" +
             "  - python-best-practices\n" +
             "  - python-code-style";
+
+    private static final String DEFAULT_JAVASCRIPT_RULESET_CONFIG =
+        "rulesets:\n" +
+            "  - jsx-a11y\n" +
+            "  - jsx-react\n" +
+            "  - react-best-practices";
+
+    /**
+     * Based on different project settings, it returns the default ruleset configuration to populate
+     * codiga.yml with.
+     * <p>
+     * First, it checks if a Python SDK is configured, then if it isn't, it moves on to check if a file
+     * with any of the Python/JavaScript/TypeScript file extensions is present in the project.
+     *
+     * @param project the current project
+     * @return the ruleset configuration, or empty Optional, if no suitable project configuration is found
+     */
+    public static Optional<String> getDefaultRulesetsForProject(Project project) {
+        var language = isPythonSdkConfigured(project) ? LanguageEnumeration.PYTHON : findSupportedFile(project);
+        if (language == null || language == LanguageEnumeration.UNKNOWN) {
+            return Optional.empty();
+        }
+
+        return language == LanguageEnumeration.PYTHON
+            ? Optional.of(DEFAULT_PYTHON_RULESET_CONFIG)
+            : Optional.of(DEFAULT_JAVASCRIPT_RULESET_CONFIG);
+    }
+
+    private static boolean isPythonSdkConfigured(Project project) {
+        //First, check if a Python SDK is configured on project level
+        Sdk projectSdk = ProjectRootManager.getInstance(project).getProjectSdk();
+        boolean isPythonSdkConfigured = projectSdk != null && PYTHON_SDK_ID_NAME.equals(projectSdk.getSdkType().getName());
+        //If Python is not configured on project level, there might still be one or more modules that have Python SDK configured.
+        if (!isPythonSdkConfigured) {
+            Module[] modules = ModuleManager.getInstance(project).getModules();
+            isPythonSdkConfigured = Arrays.stream(modules)
+                .map(ModuleRootManager::getInstance)
+                .map(ModuleRootModel::getSdk)
+                .filter(Objects::nonNull)
+                .anyMatch(moduleSdk -> PYTHON_SDK_ID_NAME.equals(moduleSdk.getSdkType().getName()));
+        }
+        return isPythonSdkConfigured;
+    }
+
+    /**
+     * Iterates through the supported file extensions and checks if there is at least one file in the project with that extension.
+     *
+     * @param project the current project
+     * @return the language for a file found with a supported extension, or null of no such file was found
+     */
+    @Nullable
+    private static LanguageEnumeration findSupportedFile(Project project) {
+        return FILE_EXTENSIONS.stream()
+            .filter(extension -> !FilenameIndex.getAllFilesByExt(project, extension, GlobalSearchScope.projectScope(project)).isEmpty())
+            .map(LanguageUtils::getLanguageFromExtension)
+            .findFirst()
+            .orElse(null);
+    }
 
     private CodigaRulesetConfigs() {
         //Utility class


### PR DESCRIPTION
### Changes
- Added default JavaScript ruleset suggestion for JS and TS files.
  - Moved some of the logic from `RosieStartupActivity` to `CodigaRulesetConfigs`.
- Updated the logic to show the suggestion as follows
  - if Python SDK is configured, show the notification,
  - if Python SDK is not configured, but at least one file with one of py, js, jsx, ts or tsx extension is present in the project, then show the notification, and `codiga.yml` is created with a content according to the found file extension.