### PR TITLE
Add null check to shortcut cache garbage collection

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/cache/ShortcutCache.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/cache/ShortcutCache.java
@@ -156,12 +156,12 @@ public final class ShortcutCache {
         // Get the keys to remove
         for (ShortcutCacheKey key: cache.keySet()){
             ShortcutCacheValue value = cache.get(key);
-            if (value.shouldBeDeleted()) {
+            if (value != null && value.shouldBeDeleted()) {
                 keysToRemove.add(key);
             }
         }
 
-        // Remove from the mp
+        // Remove from the map
         for(ShortcutCacheKey key: keysToRemove) {
             cache.remove(key);
         }


### PR DESCRIPTION
### Changes
- Added null check in `ShortcutCache#garbageCollect()` method.
  - Related to Rollbar item 49.