### PR TITLE
Add Jackson dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,10 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("commons-io:commons-io:2.11.0")
 
+    //codiga.yml parsing
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.1")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.1")
+
     implementation("com.google.code.gson:gson:2.10")
 
     // markdown support


### PR DESCRIPTION
### Changes
- Added `jackson-databind` and `jackson-dataformat-yaml` dependencies.
  - Before, the plugin relied on the `YAMLFactory` and related classes to come from/via the intellij-platform.
- Related to Rollbar item 50.