### PR TITLE
Add null check and error balloon for Codiga Assistant notification

### DIFF
--- a/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
+++ b/src/main/java/io/codiga/plugins/jetbrains/starter/AppStarter.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.serviceContainer.AlreadyDisposedException;
@@ -110,23 +111,35 @@ public class AppStarter implements StartupActivity {
                 .addAction(new AnAction("Snippets") {
                     @Override
                     public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                        ActionManager.getInstance().getAction("com.code_inspector.plugins.intellij.actions.AssistantUseRecipeAction")
-                            .actionPerformed(new AnActionEvent(null,
-                                DataManager.getInstance().getDataContext(FileEditorManager.getInstance(project).getSelectedEditor().getComponent()),
-                                ActionPlaces.UNKNOWN,
-                                new Presentation(),
-                                ActionManager.getInstance(), 0));
+                        //The selected editor is null when the user has no open editor by default, or closed all of them before invoking this action.
+                        var selectedEditor = FileEditorManager.getInstance(project).getSelectedEditor();
+                        if (selectedEditor != null) {
+                            ActionManager.getInstance().getAction("com.code_inspector.plugins.intellij.actions.AssistantUseRecipeAction")
+                                .actionPerformed(new AnActionEvent(null,
+                                    DataManager.getInstance().getDataContext(selectedEditor.getComponent()),
+                                    ActionPlaces.UNKNOWN,
+                                    new Presentation(),
+                                    ActionManager.getInstance(), 0));
+                        } else {
+                            DumbService.getInstance(project).showDumbModeNotification("There is no active editor to invoke the selected action in.");
+                        }
                     }
                 })
                 .addAction(new AnAction("Shortcuts") {
                     @Override
                     public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                        ActionManager.getInstance().getAction("com.code_inspector.plugins.intellij.actions.AssistantListShortcuts")
-                            .actionPerformed(new AnActionEvent(null,
-                                DataManager.getInstance().getDataContext(FileEditorManager.getInstance(project).getSelectedEditor().getComponent()),
-                                ActionPlaces.UNKNOWN,
-                                new Presentation(),
-                                ActionManager.getInstance(), 0));
+                        //The selected editor is null when the user has no open editor by default, or closed all of them before invoking this action.
+                        var selectedEditor = FileEditorManager.getInstance(project).getSelectedEditor();
+                        if (selectedEditor != null) {
+                            ActionManager.getInstance().getAction("com.code_inspector.plugins.intellij.actions.AssistantListShortcuts")
+                                .actionPerformed(new AnActionEvent(null,
+                                    DataManager.getInstance().getDataContext(selectedEditor.getComponent()),
+                                    ActionPlaces.UNKNOWN,
+                                    new Presentation(),
+                                    ActionManager.getInstance(), 0));
+                        } else {
+                            DumbService.getInstance(project).showDumbModeNotification("There is no active editor to invoke the selected action in.");
+                        }
                     }
                 })
                 .addAction(new AnAction("Doc") {


### PR DESCRIPTION
### Changes
- Added a null check, and displaying an error balloon when the user invokes the Snippets or Shortcuts action from the Codiga Coding Assistant notification, and there is no editor open.
  - The balloon is displayed for better user experience, so that users know why there is nothing happening in that case.
- This is for Rollbar item 53.

![There is no active editor](https://user-images.githubusercontent.com/5739987/218673747-ff5a39f3-2f5e-4225-ad32-370fb7aa82b8.png)
